### PR TITLE
Allow for sessions across mulitple instances.

### DIFF
--- a/.cg-deploy/manifests/production/manifest-api.yml
+++ b/.cg-deploy/manifests/production/manifest-api.yml
@@ -5,7 +5,7 @@ applications:
   path: ../../../server
   buildpack: https://github.com/cloudfoundry/nodejs-buildpack
   memory: 256M
-  instances: 1
+  instances: 2
   services:
     - eauth-service-provider
     - intake-client-service

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Login.gov uses the openid-client passport plugin for the OpenID Connect protocol
 
 Due to security restrictions testing can't be done locally, you must use a server on cloud.gov. Setting the PLATFORM environment variable will bypass all authentication checks.
 
-Note: if running in a clustered environment Session Affinity (sticky sessions) should be configured.
+Note: we use `cookie-sessions` to with keys bound to the environment to allow for running in a clustered environment.
 
 #### Mock Data
 

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,7 @@
     "jsdom": "^12.0.0",
     "jsonwebtoken": "^8.3.0",
     "juice": "^4.3.2",
+    "keygrip": "^1.0.2",
     "lodash": "^4.17.5",
     "markdown": "^0.5.0",
     "moment": "^2.22.2",

--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -29,6 +29,7 @@ const swaggerUi = require('swagger-ui-express');
 const swaggerDocument = require('./docs/swagger.json');
 const loggerParams = { json: true, colorize: true, timestamp: true };
 const expressWinston = require('express-winston');
+var Keygrip = require('keygrip')
 
 // Create the express application.
 const app = express();
@@ -47,7 +48,7 @@ app.use(
 app.use(bodyParser.json());
 app.use(bodyParser.xml());
 
-/** Logging middlelayer */
+/** Logging middleware */
 expressWinston.requestWhitelist = ['url',
   'headers.host',
   'headers.user-agent',
@@ -73,11 +74,11 @@ app.use(expressWinston.errorLogger({
   ]
 }));
 
-/**  Cookies for session management. Passport needs cookies, otherwise we'd be using JWTs. */
+/**  Cookies for session management. */
 app.use(
   session({
     name: 'session',
-    keys: [util.getRandomString(32), util.getRandomString(32)],
+    keys: new Keygrip([vcapConstants.PERMIT_SECRET], 'sha256', 'base64'),
     cookie: {
       secure: true,
       httpOnly: true,


### PR DESCRIPTION
## Summary
Resolves Issue #[154](https://github.com/18F/fs-open-forest-platform/issues/154)

*Describe the pull request here, including any supplemental information needed to understand it.*
Changes the cookie-session to use a key derived from the vcap secret for shared session key using keygrip, so that it can be shared across mulitple instances.

## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] allow for in prod to maintain session across sessions

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [X] The change has been documented
  - [X] Associated OpenAPI documentation has been updated

