### PR TITLE
328 forest dropdown

### DIFF
--- a/.cg-deploy/manifests/production/manifest-frontend.yml
+++ b/.cg-deploy/manifests/production/manifest-frontend.yml
@@ -5,6 +5,7 @@ applications:
   routes:
    - route: openforest.fs.usda.gov
   memory: 64M
+  instances: 2
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
   env:
     FORCE_HTTPS: true

--- a/frontend/src/app/trees/forests/forest-finder/forest-finder.component.html
+++ b/frontend/src/app/trees/forests/forest-finder/forest-finder.component.html
@@ -15,6 +15,7 @@
            id="forest-finder-select"
            name="forestFinderSelect"
           >
+            <option value="" disabled selected>Select a forest</option>
             <option role='option' *ngFor="let forest of forests" [ngValue]="forest">{{ forest.description }}</option>
           </select>
           <div id='forest-finder-error' aria-live="assertive" [ngClass]="{ 'hidden': !showForestSelectError }">


### PR DESCRIPTION
## Summary
Resolves Issue #[328](https://github.com/18F/fs-open-forest-platform/issues/328)

Adds a default, but disabled `Select a forest` option on the choose a forest dropdown. Of note it looks like the `dropdown` does not display an option unless selected.

## Impacted Areas of the Site
Christmas tree frontend
## Optional Screenshots
![image](https://user-images.githubusercontent.com/5840989/45044828-38f7eb00-b03f-11e8-9bb7-3ed266b5c923.png)


## This pull request changes...
- [x] Adds a default, but disabled `Select a forest` option on the choose a forest dropdown

## This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

