### PR TITLE
Fax validation error

### DIFF
--- a/frontend/src/app/application-forms/_services/application-fields.service.ts
+++ b/frontend/src/app/application-forms/_services/application-fields.service.ts
@@ -98,7 +98,9 @@ export class ApplicationFieldsService {
   }
 
   phoneChangeSubscribers(parentForm, type) {
-    parentForm.get(`${type}.tenDigit`).valueChanges.subscribe(value => {
+    parentForm.get(`${type}.tenDigit`).valueChanges
+    .filter(data => parentForm.get(`${type}.tenDigit`).valid)
+    .subscribe(value => {
       if (value) {
         parentForm.patchValue({ [type]: { areaCode: value.substring(0, 3) } });
         parentForm.patchValue({ [type]: { prefix: value.substring(3, 6) } });
@@ -107,10 +109,12 @@ export class ApplicationFieldsService {
     });
   }
 
+
   removeAdditionalPhone(parentForm) {
     parentForm.removeControl('eveningPhone');
   }
 
+ 
   simpleRequireToggle(toggleField, dataField) {
     toggleField.valueChanges.subscribe(value => {
       this.updateValidators(dataField, value, 512);

--- a/frontend/src/app/application-forms/fields/fax.component.ts
+++ b/frontend/src/app/application-forms/fields/fax.component.ts
@@ -17,15 +17,17 @@ export class FaxComponent implements OnInit {
   createForm() {
     this.formName = 'fax';
     this[this.formName] = this.formBuilder.group({
-      areaCode: [null, Validators.maxLength(3)],
+      areaCode: ['', Validators.maxLength(3)],
       extension: [null, [Validators.minLength(1), Validators.maxLength(6)]],
-      number: [null, Validators.maxLength(4)],
-      prefix: [null, Validators.maxLength(3)],
+      number: ['', Validators.maxLength(4)],
+      prefix: ['', Validators.maxLength(3)],
       tenDigit: ['', [Validators.minLength(10), Validators.maxLength(10)]]
     });
     this.parentForm.addControl(this.formName, this[this.formName]);
     this.fax = this.parentForm.get('fax');
   }
+
+
 
   changeSubscribers() {
     this.parentForm.get('fax.extension').valueChanges.subscribe(value => {
@@ -43,8 +45,11 @@ export class FaxComponent implements OnInit {
     this.afs.phoneChangeSubscribers(this.parentForm, 'fax');
   }
 
+ 
   ngOnInit() {
     this.createForm();
     this.changeSubscribers();
   }
 }
+
+


### PR DESCRIPTION
## Summary
Resolves Issue #[355](https://github.com/18F/fs-open-forest-platform/issues/Addnumber)

Added a filter to check if fax number is valid before allowing patchvalue to set areacode, prefix, and number which was what was causing rxjs to store values deleted.
## Impacted Areas of the Site
outfitters application

## Optional Screenshots

## This pull request changes...
- [ ] Allows users to either leave fax blank, fill out completely with validation, or start to type fax number, and delete to leave blank


## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

