### PR TITLE
Open forest permit emails

### DIFF
--- a/frontend/src/app/application-forms/_services/application-fields.service.ts
+++ b/frontend/src/app/application-forms/_services/application-fields.service.ts
@@ -98,7 +98,9 @@ export class ApplicationFieldsService {
   }
 
   phoneChangeSubscribers(parentForm, type) {
-    parentForm.get(`${type}.tenDigit`).valueChanges.subscribe(value => {
+    parentForm.get(`${type}.tenDigit`).valueChanges
+    .filter(data => parentForm.get(`${type}.tenDigit`).valid)
+    .subscribe(value => {
       if (value) {
         parentForm.patchValue({ [type]: { areaCode: value.substring(0, 3) } });
         parentForm.patchValue({ [type]: { prefix: value.substring(3, 6) } });
@@ -107,10 +109,12 @@ export class ApplicationFieldsService {
     });
   }
 
+
   removeAdditionalPhone(parentForm) {
     parentForm.removeControl('eveningPhone');
   }
 
+ 
   simpleRequireToggle(toggleField, dataField) {
     toggleField.valueChanges.subscribe(value => {
       this.updateValidators(dataField, value, 512);

--- a/frontend/src/app/application-forms/_services/application-fields.service.ts
+++ b/frontend/src/app/application-forms/_services/application-fields.service.ts
@@ -114,7 +114,6 @@ export class ApplicationFieldsService {
     parentForm.removeControl('eveningPhone');
   }
 
- 
   simpleRequireToggle(toggleField, dataField) {
     toggleField.valueChanges.subscribe(value => {
       this.updateValidators(dataField, value, 512);

--- a/frontend/src/app/application-forms/fields/fax.component.ts
+++ b/frontend/src/app/application-forms/fields/fax.component.ts
@@ -45,7 +45,6 @@ export class FaxComponent implements OnInit {
     this.afs.phoneChangeSubscribers(this.parentForm, 'fax');
   }
 
- 
   ngOnInit() {
     this.createForm();
     this.changeSubscribers();

--- a/frontend/src/app/application-forms/fields/fax.component.ts
+++ b/frontend/src/app/application-forms/fields/fax.component.ts
@@ -17,15 +17,17 @@ export class FaxComponent implements OnInit {
   createForm() {
     this.formName = 'fax';
     this[this.formName] = this.formBuilder.group({
-      areaCode: [null, Validators.maxLength(3)],
+      areaCode: ['', Validators.maxLength(3)],
       extension: [null, [Validators.minLength(1), Validators.maxLength(6)]],
-      number: [null, Validators.maxLength(4)],
-      prefix: [null, Validators.maxLength(3)],
+      number: ['', Validators.maxLength(4)],
+      prefix: ['', Validators.maxLength(3)],
       tenDigit: ['', [Validators.minLength(10), Validators.maxLength(10)]]
     });
     this.parentForm.addControl(this.formName, this[this.formName]);
     this.fax = this.parentForm.get('fax');
   }
+
+
 
   changeSubscribers() {
     this.parentForm.get('fax.extension').valueChanges.subscribe(value => {
@@ -43,8 +45,11 @@ export class FaxComponent implements OnInit {
     this.afs.phoneChangeSubscribers(this.parentForm, 'fax');
   }
 
+ 
   ngOnInit() {
     this.createForm();
     this.changeSubscribers();
   }
 }
+
+

--- a/server/src/email/templates/special-use-common/application-accepted.es6
+++ b/server/src/email/templates/special-use-common/application-accepted.es6
@@ -5,9 +5,9 @@ module.exports = (application, defaultApplicationDetails) => {
 
   return {
     to: application.applicantInfoEmailAddress,
-    subject: 'An update on your recent permit application to the Forest Service.',
+    subject: 'An update on your recent Open Forest permit application to the Forest Service.',
     body: `
-      Permit application status update
+      Open Forest permit application status update
       *********************************
 
       The permit application listed below has passed a preliminary review for the ${application.forestName}! An administrator will now do a more in-depth review and may be contacting you to get any additional details or documents needed.
@@ -24,7 +24,7 @@ module.exports = (application, defaultApplicationDetails) => {
       ${defaultForestContact.text}
       `,
     html: `
-    <h2>Permit application status update</h2>
+    <h2>Open Forest permit application status update</h2>
     <p>The permit application listed below has passed a preliminary review!
      An administrator will now do a more in-depth review and may be contacting
      you to get any additional details or documents needed.</p>


### PR DESCRIPTION
Add Open Forest to permit-created.es6 email

added Open Forest references for consistency

## Summary
Resolves Issue #[183](https://github.com/18F/fs-open-forest-platform/issues/183)

Adds Open Forest to permit confirmation email

##  Application Accepted email only

## This pull request changes...
- [ ] language in application accepted email

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

