### PR TITLE
Change noncomm 48 hour refs to 2 biz days

### DIFF
--- a/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.html
+++ b/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.html
@@ -11,7 +11,7 @@
       <div>
         <ol>
           <li>Fill out and submit the application below.</li>
-          <li>Once submitted, your application will go through a preliminary review within 48 hours.</li>
+          <li>Once submitted, your application will go through a preliminary review within two business days.</li>
           <li>If additional information is needed following the preliminary review and acceptance, a representative of the National Forest Service will contact you via email.</li>
           <li>Once your application is approved, you will receive your permit within 2 weeks. If your application is not approved, you will be notified via email.</li>
         </ol>

--- a/frontend/src/app/application-forms/application-noncommercial-group/noncommercial-learn-more.component.ts
+++ b/frontend/src/app/application-forms/application-noncommercial-group/noncommercial-learn-more.component.ts
@@ -43,7 +43,7 @@ export class NoncommercialLearnMoreComponent {
         type: 'anchor',
         sectionCopy: `
         <p>Permit applications must be submitted at least 72 hours in advance of the proposed activity
-        and will be evaluated by the Forest Service within 48 hours of receipt. Otherwise,
+        and will be evaluated by the Forest Service within two business days of receipt. Otherwise,
         they are deemed granted. All permit applications will be evaluated using the same criteria,
         regardless of the content of the event or gathering.</p>
 

--- a/frontend/src/app/application-forms/application-submitted/application-submitted.component.html
+++ b/frontend/src/app/application-forms/application-submitted/application-submitted.component.html
@@ -21,7 +21,7 @@
       <ol class="usa-grid-full">
         <li class="next-steps usa-width-one-fourth">
           <span class="step-number">1</span>
-          <p><strong>Your application will be reviewed by our staff<span *ngIf="type !== 'temp-outfitter'"> within 48 hours</span>.</strong></p>
+          <p><strong>Your application will be reviewed by our staff<span *ngIf="type !== 'temp-outfitter'"> within two business days</span>.</strong></p>
         </li>
         <li class="next-steps usa-width-one-fourth">
           <span class="step-number">2</span>

--- a/server/src/email/email-templates.es6
+++ b/server/src/email/email-templates.es6
@@ -32,7 +32,7 @@ emailTemplates.noncommercialApplicationSubmittedConfirmation = application => {
   return specialUseSubmittedConfirm(
     application,
     defaultNoncommerialApplicationDetails,
-    ' within 48 hours'
+    ' within two business days'
   );
 };
 emailTemplates.tempOutfitterApplicationSubmittedConfirmation = application => {

--- a/server/src/email/templates/special-use-common/application-submitted-confirmation.es6
+++ b/server/src/email/templates/special-use-common/application-submitted-confirmation.es6
@@ -34,7 +34,7 @@ module.exports = (application, defaultApplicationDetails, reviewTime) => {
     ${defaultApplicationDetails.html(application)}
     <h2>What happens next?</h2>
     <ol>
-      <li>Your application will be reviewed by our staff within 48 hours.</li>
+      <li>Your application will be reviewed by our staff${reviewTime}.</li>
       <li>If additional information is needed, a representative of the National Forest Service will contact you via email to resolve any issues.</li>
       <li>Once your application has been reviewed by our staff, you will be notified of the application status.</li>
       <li>If your application is approved, you will receive your permit within 2 weeks of approval.</li>


### PR DESCRIPTION
## Summary
Resolves Issue #[353](https://github.com/18F/fs-open-forest-platform/issues/353

*Describe the pull request here, including any supplemental information needed to understand it.*
Where ever the site mentions that staff will review a noncomm app within 48 hours, change to 2 business days.

## Impacted Areas of the Site
- email
- noncomm app
- noncomm learnmore

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

