### PR TITLE
Use promises for email util

### DIFF
--- a/server/src/controllers/christmas-tree.es6
+++ b/server/src/controllers/christmas-tree.es6
@@ -393,31 +393,24 @@ const checkPermitValid = permitExpireDate => {
  * @function generateRulesAndEmail - Private function to generate svg, png, and rules html of a permit and send out email
  * @param {Object} permit - permit object
  */
-const generateRulesAndEmail = permit => {
+const generateRulesAndEmail = permit =>
   permitSvgService
     .generatePermitSvg(permit)
-    .then(permitSvg => {
-      permitSvgService.generatePng(permitSvg)
-        .then(permitPng => {
-          permitSvgService
-            .generateRulesHtml(true, permit)
-            .then(rulesHtml => {
-              permit.permitUrl = paygov.createSuccessUrl(permit.christmasTreesForest.forestAbbr, permit.permitId);
-              let rulesText = htmlToText.fromString(rulesHtml, {
-                wordwrap: 130,
-                ignoreImage: true
-              });
-              sendEmail(permit, permitPng, rulesHtml, rulesText);
-            })
-            .catch(error => {
-              logger.error(error);
-            });
-        });
+    .then(() => Promise.all([
+      permitSvgService.generatePng(permit),
+      permitSvgService.generateRulesHtml(true, permit),
+    ]))
+    .then((permitPng, rulesHtml) => {
+      permit.permitUrl = paygov.createSuccessUrl(permit.christmasTreesForest.forestAbbr, permit.permitId);
+      let rulesText = htmlToText.fromString(rulesHtml, {
+        wordwrap: 130,
+        ignoreImage: true
+      });
+      return sendEmail(permit, permitPng, rulesHtml, rulesText);
     })
     .catch(error => {
       logger.error(error);
     });
-};
 
 /**
  * @function getOnePermit - API function to get a permit.

--- a/server/src/email/email-util.es6
+++ b/server/src/email/email-util.es6
@@ -47,32 +47,35 @@ emailUtil.transporter = nodemailer.createTransport(smtpConfig);
  * @param {boolean} attachments - email contains attachments
  */
 emailUtil.send = (to, subject, body, html = false, attachments = false) => {
-  const bodyAndNoReply = `${body}
+  return new Promise((resolve, reject) => {
+    const bodyAndNoReply = `${body}
 
-    Please do not reply to this message.
-    This email message was sent from a notification-only address that cannot accept incoming email`;
+      Please do not reply to this message.
+      This email message was sent from a notification-only address that cannot accept incoming email`;
 
-  let mailOptions = {
-    from: `"Forest Service online permits" <${vcapConstants.SMTP_USERNAME}>`,
-    to: to,
-    subject: subject,
-    text: bodyAndNoReply // plain text
-  };
-  if (html) {
-    mailOptions.html = html;
-  }
-  if (attachments) {
-    mailOptions.attachments = attachments;
-  }
-  if (vcapConstants.SMTP_HOST) {
-    emailUtil.transporter.sendMail(mailOptions, error => {
-      if (error) {
-        logger.error('NODE_MAILER_SMTP_ERROR', error);
-      } else {
-        logger.info('Email successfully sent');
-      }
-    });
-  }
+    let mailOptions = {
+      from: `"Forest Service online permits" <${vcapConstants.SMTP_USERNAME}>`,
+      to: to,
+      subject: subject,
+      text: bodyAndNoReply // plain text
+    };
+    if (html) {
+      mailOptions.html = html;
+    }
+    if (attachments) {
+      mailOptions.attachments = attachments;
+    }
+    if (vcapConstants.SMTP_HOST) {
+      emailUtil.transporter.sendMail(mailOptions, error => {
+        if (error) {
+          logger.error('NODE_MAILER_SMTP_ERROR', error);
+        } else {
+          logger.info('Email successfully sent');
+        }
+        resolve();
+      });
+    }
+  }):
 };
 
 /**
@@ -82,16 +85,21 @@ emailUtil.send = (to, subject, body, html = false, attachments = false) => {
  * @param {array} attachments - email attachments array
  */
 emailUtil.sendEmail = (templateName, data, attachments = []) => {
-  if (emailTemplates[templateName]) {
-    const emailAttachments = htmlTemplate.attachments.concat(attachments);
-    const template = emailTemplates[templateName](data);
-    let html;
-    if (template.html) {
-      html = htmlTemplate.forestService(template.html,template.subject);
-      html = juice(html);
-    }
-    emailUtil.send(template.to, template.subject, template.body, html, emailAttachments);
+  if (!emailTemplates[templateName]) {
+    const err = new Error(`You must specify a valid template name. templateName=${templateName}`);
+    err.templateName = templateName;
+    return Promise.reject(err);
   }
+
+  const emailAttachments = htmlTemplate.attachments.concat(attachments);
+  const template = emailTemplates[templateName](data);
+  let html;
+  if (template.html) {
+    html = htmlTemplate.forestService(template.html,template.subject);
+    html = juice(html);
+  }
+
+  return emailUtil.send(template.to, template.subject, template.body, html, emailAttachments);
 };
 
 module.exports = emailUtil;


### PR DESCRIPTION
Adds promises to the email util, making sure not to reject on failures since
that is the existing behavior.

## Summary
Resolves Issue #[X](https://github.com/18F/fs-open-forest-platform/issues/Addnumber)

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1
- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

