### PR TITLE
Conditionally mock only when running the tests

### DIFF
--- a/.circleci/run-e2e.sh
+++ b/.circleci/run-e2e.sh
@@ -1,3 +1,5 @@
+export NODE_ENV=test
+
 if [ $# -lt 1 ]
 then
     echo 'Error: No arguments provided.'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ _Staging:_
 # U.S. Forest Service Permit Platform
 
 
-** Platform for sale of Christmas tree permits and intake of special use applications for the U.S. Forest Service **
+**Platform for sale of Christmas tree permits and intake of special use applications for the U.S. Forest Service**
 
 ## Welcome
 
@@ -50,7 +50,6 @@ As the first two-way interaction-focused Forest Service online application, Open
 		- [Available commands](#available-commands)
 		- [Server API Documentation](#server-api-documentation)
 		- [Authentication](#authentication)
-		- [Mock Data](#mock-data)
 		- [Forest start and end dates](#forest-start-and-end-dates)
 		- [JWT Usage](#jwt-usage)
 		- [Pay.Gov integration](#paygov-integration)
@@ -187,16 +186,13 @@ Due to security restrictions testing can't be done locally, you must use a serve
 
 Note: we use `cookie-sessions` to with keys bound to the environment to allow for running in a clustered environment.
 
-#### Mock Data
-
-Some models (e.g. christmasTreesForests) use a sequelize hook to change the data as configured in the seed commands
-at run-time for purposes of testing. An alert is also displayed in the frontend. Mock data application uses the `NODE_ENV` and environment values in the server and frontend code respectively.
-
 #### Forest start and end dates
 
 Forest tree cutting start and end dates are saved in the database as a UTC DateTime object. When updating the start and end dates for the forest in the database, you must consider daylight savings, the forest timezone and calculate the offset.
 
 Forest dates on the frontend use the forest's timezone to calculate the correct date and time.
+
+For local development, go to an [the changes season dates page to open a forest](http://localhost:4200/admin/christmas-trees/season-dates)
 
 #### JWT Usage
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,9 +17,9 @@
     "build-test-pa11y": "./development-configurations/build-test-pa11y.sh",
     "snyk-test": "snyk test",
     "start": "ng serve",
-    "test:ci": "ng test --karma-config ./development-configurations/karma.conf --code-coverage --watch=false --source-map=false --progress=false",
-    "test": "ng test --karma-config ./development-configurations/karma.conf",
-    "test:coverage": "ng test --karma-config ./development-configurations/karma.conf --watch=false --source-map --code-coverage",
+    "test:ci": "NODE_ENV=test ng test --karma-config ./development-configurations/karma.conf --code-coverage --watch=false --source-map=false --progress=false",
+    "test": "NODE_ENV=test ng test --karma-config ./development-configurations/karma.conf",
+    "test:coverage": "NODE_ENV=test ng test --karma-config ./development-configurations/karma.conf --watch=false --source-map --code-coverage",
     "typedoc": "typedoc",
     "update-version": "node ./replace.build.js"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
     "dist": "ng build --prod --configuration=production",
     "dist-trees": "ng build --configuration=trees",
     "dist-prod": "ng build --configuration=production",
-    "docs": "yarn run typedoc --out ./src/assets/typedoc --exclude '**/*.spec.ts' ./src/ --module commonjs",
+    "docs": "npm run typedoc --out ./src/assets/typedoc --exclude '**/*.spec.ts' ./src/ --module commonjs",
     "e2e:cidkr": "ng e2e --port=4200 --protractor-config ./development-configurations/protractor.conf.js --suite=docker-smoke-test",
     "e2e": "ng e2e --protractor-config ./development-configurations/protractor.conf --port=4200",
     "lint": "ng lint",

--- a/server/Procfile
+++ b/server/Procfile
@@ -1,1 +1,1 @@
-web: npm run migrate && npm run undoAllSeed && npm run seed && npm run start
+web: npm run migrate && npm run start

--- a/server/package.json
+++ b/server/package.json
@@ -83,9 +83,9 @@
     "unionized": "^4.12.2"
   },
   "scripts": {
-    "coverage": "nyc --check-coverage --lines 90 --reporter=html --reporter=text --reporter=lcov --extension .es6 yarn test",
-    "dev": "yarn; yarn copy-frontend-assets; sequelize db:migrate; NODE_ENV=local nodemon ./src/app.es6",
-    "dev:user": "yarn; yarn copy-frontend-assets; sequelize db:migrate; NODE_ENV=local nodemon ./src/app.es6 user",
+    "coverage": "nyc --check-coverage --lines 90 --reporter=html --reporter=text --reporter=lcov --extension .es6 npm test",
+    "dev": "npm run copy-frontend-assets; sequelize db:migrate; NODE_ENV=local nodemon ./src/app.es6",
+    "dev:user": "npm run dev -- user",
     "copy-frontend-assets": "./copy-frontend-assets.sh",
     "lint": "eslint **/**/*.es6",
     "migrate": "sequelize db:migrate",
@@ -94,11 +94,11 @@
     "snyk-protect": "snyk protect",
     "start": "node ./src/app.es6",
     "test": "NODE_ENV=test mocha ./test/**/*.es6 ./test/*.es6 --exit",
-    "docs": "yarn run jsdoc",
+    "docs": "npm run jsdoc",
     "undoAllSeed": "sequelize db:seed:undo:all",
     "undoAllMigrate": "sequelize db:migrate:undo:all",
     "undoLastMigrate": "sequelize db:migrate:undo",
-    "jsdoc": "./node_modules/.bin/jsdoc -c .jsdoc.json -d docs/code -t ./node_modules/ink-docstrap/template -r ."
+    "jsdoc": "jsdoc -c .jsdoc.json -d docs/code -t ./node_modules/ink-docstrap/template -r ."
   },
   "engines": {
     "node": "^8.11.3"

--- a/server/package.json
+++ b/server/package.json
@@ -83,7 +83,7 @@
     "unionized": "^4.12.2"
   },
   "scripts": {
-    "coverage": "nyc --check-coverage --lines 90 --reporter=html --reporter=text --reporter=lcov --extension .es6 mocha ./test/**/*.es6 ./test/*.es6 --exit",
+    "coverage": "nyc --check-coverage --lines 90 --reporter=html --reporter=text --reporter=lcov --extension .es6 yarn test",
     "dev": "yarn; yarn copy-frontend-assets; sequelize db:migrate; NODE_ENV=local nodemon ./src/app.es6",
     "dev:user": "yarn; yarn copy-frontend-assets; sequelize db:migrate; NODE_ENV=local nodemon ./src/app.es6 user",
     "copy-frontend-assets": "./copy-frontend-assets.sh",

--- a/server/package.json
+++ b/server/package.json
@@ -93,7 +93,7 @@
     "snyk-test": "snyk test --file=package.json",
     "snyk-protect": "snyk protect",
     "start": "node ./src/app.es6",
-    "test": "mocha ./test/**/*.es6 ./test/*.es6 --exit",
+    "test": "NODE_ENV=test mocha ./test/**/*.es6 ./test/*.es6 --exit",
     "docs": "yarn run jsdoc",
     "undoAllSeed": "sequelize db:seed:undo:all",
     "undoAllMigrate": "sequelize db:migrate:undo:all",

--- a/server/src/models/christmas-trees-forests.es6
+++ b/server/src/models/christmas-trees-forests.es6
@@ -108,7 +108,7 @@ module.exports = function(sequelize, DataTypes) {
   );
 
   christmasTreesForests.addHook('afterFind', forest => {
-    if (util.isLocalOrCI()) {
+    if (util.isTest()) {
       if (forest && forest.startDate) {
         // forest is closed and configured for testing uncomment this block and update
         //the forest id

--- a/server/src/services/util.es6
+++ b/server/src/services/util.es6
@@ -247,6 +247,14 @@ util.isLocalOrCI = () => {
 };
 
 /**
+ * @function env - Return the current environment
+ * @return {bool} - True if we are in an automated test environment
+ */
+util.isTest = () => {
+  return process.env.NODE_ENV === 'test';
+};
+
+/**
  * @function isProduction - is production flag
  * @return {boolean} - NODE_ENV is production
  */


### PR DESCRIPTION

## Summary
This is part of #346

In development, developers need to be able to configure season open/close dates
explicitly and this mocking prevents them from doing that. Keep the mocking
exclusively to a test configuration.

## Impacted Areas of the Site
N/A

## Optional Screenshots
N/A

## This pull request changes...
- [x] how developers can edit season open/close dates in the admin interface.

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

