### PR TITLE
Send special user returning from auth back to application (rather than the page that they request from)

### DIFF
--- a/frontend/src/app/shared/button/app-button.component.html
+++ b/frontend/src/app/shared/button/app-button.component.html
@@ -6,7 +6,7 @@
 </a>
 
 <div *ngIf="btnAlt">
-  <a class="usa-button-primary-alt usa-button usa-button-big display-inline" [routerLink]="link">
+  <a class="usa-button-primary-alt usa-button usa-button-big display-inline" [routerLink]="link" (click)="setRequestingUrl()">
     {{buttonText}}
     <span *ngIf="authentication.user"  class="button-hint usa-form-hint">Apply now</span>
   </a>

--- a/frontend/src/app/shared/button/app-button.component.ts
+++ b/frontend/src/app/shared/button/app-button.component.ts
@@ -11,4 +11,10 @@ export class AppButtonComponent {
   @Input() btnAlt: false;
 
   constructor(public authentication: AuthenticationService) {}
+
+  setRequestingUrl() {
+    if (!this.authentication.user) {
+      localStorage.setItem('requestingUrl', this.link);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
Resolves Issue #[371](https://github.com/18F/fs-open-forest-platform/issues/371)

*Describe the pull request here, including any supplemental information needed to understand it.*
- set local storage requesting url if user not authed so that the applicant goes back to the application link rather than back to the page that they clicked into the login from.

Note: I'm not sure how we can test this outside of staging, because on local dev we mock out authenication.

## Impacted Areas of the Site
- special use frontend

## This pull request changes...
- [ ] when a user gets sent over to the application

## This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

