### PR TITLE
take you back to the special uses if you log out

### DIFF
--- a/server/src/auth/passport-config.es6
+++ b/server/src/auth/passport-config.es6
@@ -77,7 +77,7 @@ passportConfig.logout = (req, res) => {
   } else {
     logger.info(`AUTHENTICATION: ${req.user.email} logged out via eAuth.`);
     req.logout();
-    return res.redirect(vcapConstants.INTAKE_CLIENT_BASE_URL);
+    return res.redirect(`${vcapConstants.INTAKE_CLIENT_BASE_URL}/mbs`);
   }
 };
 

--- a/server/test/passport-config.spec.es6
+++ b/server/test/passport-config.spec.es6
@@ -71,7 +71,7 @@ describe('logout', () => {
     );
     expect(redirect.callCount).to.equal(1);
     expect(logout.callCount).to.equal(1);
-    expect(redirect.calledWith(vcapConstants.INTAKE_CLIENT_BASE_URL)).to.be.true;
+    expect(redirect.calledWith(`${vcapConstants.INTAKE_CLIENT_BASE_URL}/mbs`)).to.be.true;
   });
   it('should redirect to login.gov end session enpoint for users who have the user role', () => {
     const redirect = sinon.spy();


### PR DESCRIPTION
## Summary
Since we changed the routes of the app to have special uses be a `/mbs` but when a user logs out it now will go to the xmas tree pages which would be a bit weird for public users.

## Impacted Areas of the Site
- users who log out

## Optional Screenshots

## This pull request changes...
- [x] send a user/admin logging out back to the special uses home page


## This pull request is ready to merge when...
- [x] Tests have been updated (and all tests are passing)
- [x] This code has been reviewed by someone other than the original author
- [x] The change has been documented
  - [x] Associated OpenAPI documentation has been updated

