### PR TITLE
Take off the seeders on procfile - after last commit is pushed to master

### DIFF
--- a/server/Procfile
+++ b/server/Procfile
@@ -1,1 +1,1 @@
-web: npm run migrate && npm run undoAllSeed && npm run seed && npm run start
+web: npm run migrate && npm run start


### PR DESCRIPTION
## Summary
**DO NOT MERGE** UNTIL #409 is deployed to master.

Resolves Issue #[407](https://github.com/18F/fs-open-forest-platform/issues/407)

Remove the directive to run the forest information seeders for xmas trees on the server procfile - on the push after the seeders update the forest information.

## Impacted Areas of the Site
Xmas / server startup

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1
- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

