### PR TITLE
Permit is National Forest specific, and expires.

### DIFF
--- a/frontend/src/assets/content/common/permit-rules.md
+++ b/frontend/src/assets/content/common/permit-rules.md
@@ -3,7 +3,9 @@
 #### Your permit
 
 * Must be printed to be valid and cannot be stored on a mobile device.
-* Is non-transferrable.
+* Is non-transferrable and non-refundable.
+* Is only valid for use on the National Forest listed on the permit.
+* Expires at midnight of the expiration date on the permit or when the purchased quantity of Christmas trees have been gathered, whichever comes first.
 * Cannot be reused or duplicated.
 * Cannot be used to remove more products than the permit holder has purchased.
 * Requires the permit holder to be present at time of tree cutting and transport.


### PR DESCRIPTION
Added language that is it non-refundable, valid only on the indicated National Forest, and that it expires.

## Summary
Resolves Issue #[X](https://github.com/18F/fs-open-forest-platform/issues/401)

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
All permit rules language

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1
- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

