### PR TITLE
Clarify dense forest and all people MTH

### DIFF
--- a/frontend/src/assets/content/mthood/cutting-instructions/helpful-information.md
+++ b/frontend/src/assets/content/mthood/cutting-instructions/helpful-information.md
@@ -1,6 +1,6 @@
 * Tools you might want to consider bringing with you include a handsaw to cut your tree; gloves to protect your hands; a tarp to sit on and/or to move your tree once it's cut; and rope or straps to secure your tree to your vehicle.
-* Be sure another tree has space to grow within 8 feet of the one you plan to cut. Choosing a tree from an overcrowded area will give the remaining trees more space to grow.
-* Be aware of where the tree will fall and ensure all members of your party (and your vehicle) are out of the path of the falling tree.
+* Be sure another tree has space to grow within 8 feet of the one you plan to cut. Choosing a tree from an dense forested area will give the remaining trees more space to grow.
+* Be aware of where the tree will fall and ensure all people and vehicles are out of the path of the falling tree.
 * Cut the leftover branches from the stump and scatter them.
 * Avoid trees marked with paint or designated as a wildlife tree.
 * Cut your tree a bit longer than you'll need (6-12"), so you'll have room to make a fresh cut on the bottom before putting it in water.

--- a/frontend/src/assets/content/mthood/cutting-instructions/helpful-information.md
+++ b/frontend/src/assets/content/mthood/cutting-instructions/helpful-information.md
@@ -1,6 +1,6 @@
 * Tools you might want to consider bringing with you include a handsaw to cut your tree; gloves to protect your hands; a tarp to sit on and/or to move your tree once it's cut; and rope or straps to secure your tree to your vehicle.
-* Be sure another tree has space to grow within 8 feet of the one you plan to cut. Choosing a tree from an dense forested area will give the remaining trees more space to grow.
-* Be aware of where the tree will fall and ensure all people and vehicles are out of the path of the falling tree.
+* Be sure another tree has space to grow within 8 feet of the one you plan to cut. Choosing a tree from an densely forested area will give the remaining trees more space to grow.
+* Be aware of where the tree will fall and please ensure all people and vehicles are out of the path of the falling tree.
 * Cut the leftover branches from the stump and scatter them.
 * Avoid trees marked with paint or designated as a wildlife tree.
 * Cut your tree a bit longer than you'll need (6-12"), so you'll have room to make a fresh cut on the bottom before putting it in water.


### PR DESCRIPTION
Clarify helpful cutting tips RE overcrowded vs. "dense forested area", and ensure "all people and vehicles" are out of the path of the tree for the Mt. Hood NF.

## Summary
Resolves Issue #[X](https://github.com/18F/fs-open-forest-platform/issues/428)

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1
- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

