### PR TITLE
Clarify dense forest and all people Shoshone

### DIFF
--- a/frontend/src/assets/content/shoshone/cutting-instructions/helpful-information.md
+++ b/frontend/src/assets/content/shoshone/cutting-instructions/helpful-information.md
@@ -1,4 +1,4 @@
 * Tools you might want to consider bringing with you include a handsaw to cut your tree; gloves to protect your hands; a tarp to sit on and/or to move your tree once it's cut; and rope or straps to secure your tree to your vehicle.
-* Choose a tree out of a dense forested area, which will give the remaining trees more space to grow.
-* Be aware of where the tree will fall and ensure all people and vehicles are out of the path of the falling tree.
+* Choose a tree out of a densely forested area, which will give the remaining trees more space to grow.
+* Be aware of where the tree will fall and please ensure all people and vehicles are out of the path of the falling tree.
 * Cut the leftover branches from the stump and scatter them.

--- a/frontend/src/assets/content/shoshone/cutting-instructions/helpful-information.md
+++ b/frontend/src/assets/content/shoshone/cutting-instructions/helpful-information.md
@@ -1,4 +1,4 @@
 * Tools you might want to consider bringing with you include a handsaw to cut your tree; gloves to protect your hands; a tarp to sit on and/or to move your tree once it's cut; and rope or straps to secure your tree to your vehicle.
-* Choose a tree out of an overcrowded area, which will give the remaining trees more space to grow.
-* Be aware of where the tree will fall and ensure all members of your party (and your vehicle) are out of the path of the falling tree.
+* Choose a tree out of a dense forested area, which will give the remaining trees more space to grow.
+* Be aware of where the tree will fall and ensure all people and vehicles are out of the path of the falling tree.
 * Cut the leftover branches from the stump and scatter them.


### PR DESCRIPTION
Clarify helpful cutting tips RE overcrowded vs. "dense forested area", and ensure "all people and vehicles" are out of the path of the tree for the Shoshone NF

## Summary
Resolves Issue #[X](https://github.com/18F/fs-open-forest-platform/issues/428)

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1
- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

