### PR TITLE
Fix staging: typedoc issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
           name: generate typedocs
           command: |
             cd frontend
-            mkdir ./src/assets/typedoc && npm run docs
+            mkdir -p ./src/assets/typedoc && npm run docs
       - run:
           name: server snyk protect
           command: |
@@ -271,7 +271,7 @@ jobs:
           name: generate typedocs
           command: |
             cd frontend
-            mkdir ./src/assets/typedoc && npm run docs
+            mkdir -p ./src/assets/typedoc && npm run docs
       - run:
           name: Create frontend compiled distribution
           command: |

--- a/.circleci/install-deployment-dependencies.sh
+++ b/.circleci/install-deployment-dependencies.sh
@@ -1,5 +1,12 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
 cd frontend
-yarn
-npm i -g typedoc
+npm install
+
 cd ../server
-npm i snyk
+npm install
+npm install snyk

--- a/README.md
+++ b/README.md
@@ -325,7 +325,8 @@ frontend code for each build.  This date and version will display in the applica
 ## Docs
 * [Server jsDocs](https://fs-intake-api.app.cloud.gov/docs/code/)
 * [Server api endpoints](https://fs-intake-api.app.cloud.gov/docs/api)
-* [Frontend Typedocs](https://forest-service-epermit.app.cloud.gov/assets/typedoc/)
+* [Frontend Typedocs for Production](https://openforest.fs.usda.gov/assets/typedoc/)
+* [Frontend Typedocs for Staging](https://forest-service-trees-staging.app.cloud.gov/assets/typedoc/)
 
 ## Content administration
 

--- a/README.md
+++ b/README.md
@@ -255,11 +255,9 @@ Run pa11y-ci without docker: `cd frontend; yarn run build-test-pa11y`
 
 #### Build typedoc
 
-Install typedoc globally: `yarn global add typedoc`
-
 `cd frontend`
 
-build typedoc `yarn run docs`
+build typedoc `npm run docs`
 
 typedoc are added to `frontend/src/assets/typedoc` and are accessible via url at `/assets/typedoc/index.html`
 


### PR DESCRIPTION
## Summary
Fixes issue with [running typedoc on CI](https://circleci.com/gh/18F/fs-open-forest-platform/2735).

Uses the locally installed typedoc instead of trying to globally install it (for which it doesn't have the correct permissions).

## Impacted Areas of the Site

## Optional Screenshots


## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

