### PR TITLE
Hotfix disable build optimization

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -54,13 +54,6 @@
             },
             "production": {
               "aot": false,
-              "optimization": true,
-              "outputHashing": "all",
-              "extractCss": true,
-              "namedChunks": false,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": false,
               "fileReplacements": [
                 {
                   "replace": "src/environments/environment.ts",


### PR DESCRIPTION
## Summary

Temporarily disable build optimization on production to rule that out as an issue for IE11.

https://github.com/18F/fs-open-forest-platform/issues/405

## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] production build settings

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

