### PR TITLE
Ensure no protocol on cookie domain

### DIFF
--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -75,6 +75,7 @@ app.use(expressWinston.errorLogger({
 }));
 
 /**  Cookies for session management. */
+const domain = vcapConstants.BASE_URL.replace(/https?:\/\//i, '');
 app.use(
   session({
     name: 'session',
@@ -82,7 +83,7 @@ app.use(
     cookie: {
       secure: true,
       httpOnly: true,
-      domain: vcapConstants.BASE_URL,
+      domain: domain,
       expires: new Date(Date.now() + 60 * 60 * 1000) // 1 hour
     }
   })


### PR DESCRIPTION


## Summary
 #405

Strips the protocol from the domain we use in the Set-Cookie header. The protocol is not meant to be included, so hoping by stripping it IE11 will treat it appropriately.

## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1
- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

