### PR TITLE
IE11 fixes

### DIFF
--- a/server/src/app.es6
+++ b/server/src/app.es6
@@ -31,10 +31,13 @@ const loggerParams = { json: true, colorize: true, timestamp: true };
 const expressWinston = require('express-winston');
 var Keygrip = require('keygrip');
 
+vcapConstants.nodeEnv = process.env.NODE_ENV;
+
 // Create the express application.
 const app = express();
 
-vcapConstants.nodeEnv = process.env.NODE_ENV;
+// Trust the cloud.gov X-Forwarded- headers
+app.set('trust proxy', 1);
 
 /** Use helmet for increased security. */
 app.use(helmet());

--- a/server/src/auth/usda-eauth.es6
+++ b/server/src/auth/usda-eauth.es6
@@ -67,6 +67,10 @@ eAuth.router.get(eAuth.loginPath, (req, res) => {
 
 //Callback from eAuth.
 eAuth.router.post(eAuth.callbackPath, passport.authenticate('saml'), (req, res) => {
+  // Include a P3P policy for IE11
+  // https://github.com/18F/fs-open-forest-platform/issues/405
+  res.set('P3P', 'CP="NOI ADM DEV PSAi OUR OTRo STP IND COM NAV DEM"');
+
   return res.redirect(`${vcapConstants.INTAKE_CLIENT_BASE_URL}/logged-in`);
 });
 


### PR DESCRIPTION

## Summary
#405 

The trust proxy setting is necessary for express to work correctly on cloud.gov. It tells express to trust any X-Forwarded headers sent from the proxy.

Also, sets the P3P header on the same request the Cookie is set. This was overlooked when we first added it.


## Impacted Areas of the Site

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1
- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

