### PR TITLE
DO NOT MERGE UNTIL 11/16: remove master basic auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,9 +278,6 @@ jobs:
             cd frontend
             npm run dist-prod
       - run:
-          name: Generate basic auth - will remove as final launch task
-          command: echo "${BASIC_AUTH_USER}:${BASIC_AUTH_PASS}" > frontend/dist/Staticfile.auth
-      - run:
           name: copy frontend assets into server
           command: |
             cd server


### PR DESCRIPTION
## Summary
Resolves Issue #[160](https://github.com/18F/fs-open-forest-platform/issues/160)

*Describe the pull request here, including any supplemental information needed to understand it.*
removes the basic auth to access the master site
## Impacted Areas of the Site
production deployment of the frontend

## Optional Screenshots

## This pull request changes...
- [ ] no password on master


## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

