### PR TITLE
Make page titles consistent, eliminating mention of ePermits

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Christmas tree permits | U.S. Forest Service Open Forest</title>
+  <title>U.S. Forest Service Open Forest</title>
   <base href="/">
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicons/favicon-32x32.png">

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>US Forest Service ePermit</title>
+  <title>Christmas tree permits | U.S. Forest Service Open Forest</title>
   <base href="/">
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicons/favicon-32x32.png">


### PR DESCRIPTION
When I load the site on production, I get a flash in the tab title referencing ePermits before the correct title ("Christmas tree permits | U.S. Forest Service Open Forest") loads. 

This PR is intended to fix this.

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

![screen shot 2018-11-17 at 9 47 11 pm](https://user-images.githubusercontent.com/1452369/48732994-de663800-ec06-11e8-8df5-f940d8902eed.png)
![screen shot 2018-11-17 at 9 47 14 pm](https://user-images.githubusercontent.com/1452369/48732995-de663800-ec06-11e8-99d4-c7a929c7ed44.png)
