### PR TITLE
468-report-dates

### DIFF
--- a/frontend/src/app/trees/admin/report/report.component.ts
+++ b/frontend/src/app/trees/admin/report/report.component.ts
@@ -119,7 +119,7 @@ export class ReportComponent implements OnInit, AfterViewInit {
    * @returns forest by date
    */
   getForestDate(dateField) {
-    return moment.tz(this.form.get(dateField).value, this.forest.timezone).format('MM/DD/YYYY');
+    return moment.utc(this.form.get(dateField).value).format('MM/DD/YYYY');
   }
 
   /**
@@ -150,9 +150,9 @@ export class ReportComponent implements OnInit, AfterViewInit {
       this.setReportParameters();
       this.service.getAllByDateRange(
           this.forest.id,
-          moment.tz(this.form.get('dateTimeRange.startDateTime').value, this.forest.timezone).format('YYYY-MM-DD'),
-          moment.tz(this.form.get('dateTimeRange.endDateTime').value, this.forest.timezone).format('YYYY-MM-DD')
-        )
+          moment.utc(this.form.get('dateTimeRange.startDateTime').value).format('YYYY-MM-DD'),
+          moment.utc(this.form.get('dateTimeRange.endDateTime').value).format('YYYY-MM-DD')
+          )
         .subscribe(results => {
             this.result = {
               numberOfPermits: results.numberOfPermits,

--- a/server/src/controllers/christmas-tree/admin.es6
+++ b/server/src/controllers/christmas-tree/admin.es6
@@ -27,14 +27,11 @@ const getPermitResult = permit => {
   eachPermit.permitNumber = zpad(permit.permitNumber, 8); // Adds padding to each permit number for readiblity
   
   if (permit.christmasTreesForest && permit.christmasTreesForest.timezone) {
-    eachPermit.issueDate = moment.tz(permit.updatedAt, permit.christmasTreesForest.timezone).format('MM/DD/YYYY');
-
-    eachPermit.expireDate = moment
-      .tz(permit.permitExpireDate, permit.christmasTreesForest.timezone)
-      .format('MM/DD/YYYY');
+    eachPermit.issueDate = moment(permit.updatedAt).tz(permit.christmasTreesForest.timezone).format('MM/DD/YYYY');
+    eachPermit.expireDate = moment(permit.permitExpireDate).tz(permit.christmasTreesForest.timezone).format('MM/DD/YYYY');
   } else {
-    eachPermit.issueDate = moment(permit.updatedAt).format('MM/DD/YYYY');
-    eachPermit.expireDate = moment(permit.permitExpireDate).format('MM/DD/YYYY');
+    eachPermit.issueDate = moment.tz(permit.updatedAt, permit.timezone).format('MM/DD/YYYY');
+    eachPermit.expireDate = moment.tz(permit.permitExpireDate, permit.timezone).format('MM/DD/YYYY');
   }
   eachPermit.quantity = permit.quantity;
   eachPermit.totalCost = permit.totalCost;
@@ -146,7 +143,16 @@ christmasTreeAdmin.getPermitReport = (req, res) => {
           ]
         });
       } else {
-        return returnPermitsReport([requestedPermit], res);
+        treesDb.christmasTreesForests
+        .findOne({
+          where: {
+            id: requestedPermit.forestId
+          }
+        })
+        .then(forest => {
+          requestedPermit.timezone = forest.timezone;
+          return returnPermitsReport([requestedPermit], res);
+        })
       }
     })
     .catch(error => {


### PR DESCRIPTION
## Summary

Resolution for issue:
https://github.com/18F/fs-open-forest-platform/issues/468 
Reports query date range, now match the report dates.

Replaced 3 string occurrences of this.forest.timezone with "" ,in the report.component.ts

## Impacted Areas of the Site
Generate Christmas trees permits report.

## Optional Screenshots

## This pull request changes...
- [ ] expected change 1

- [ ] expected change 2

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

