### PR TITLE
Fix staging

### DIFF
--- a/server/src/vcap-constants.es6
+++ b/server/src/vcap-constants.es6
@@ -33,6 +33,11 @@ const getUserProvided = function(name) {
   const userProvided = vcapServices['user-provided'].find(element => {
     return element.name === name;
   });
+
+  if (!userProvided) {
+    throw new Error(`No user provided service: ${name}`);
+  }
+
   return userProvided.credentials;
 };
 
@@ -97,9 +102,9 @@ vcapConstants.PAY_GOV_CERT = payGov.certificate;
 vcapConstants.PAY_GOV_PRIVATE_KEY = payGov.private_key;
 
 /** Database configuration */
-const database = getUserProvided('database') || {};
+const database = process.env.DATABASE_URL ? { url: process.env.DATABASE_URL } : getUserProvided('database');
 vcapConstants.database = {
-  url: process.env.DATABASE_URL || database.url,
+  url: database.url,
   ssl: database.ssl !== undefined ? database.ssl : process.env.NODE_ENV === 'production'
 };
 

--- a/wiki/development/environment-variables.md
+++ b/wiki/development/environment-variables.md
@@ -22,25 +22,22 @@ The following environment variables are required to run the application locally,
 
     (from https://snyk.io/account)
 
-## Local Development outside of docker
-The following environment variables are only required to run the application locally when not using docker:
-
 ### DATABASE_URL
+
+(optional) This variable can be used to connect to a different database.
 
     postgres://<user>:<pass>@localhost:<port>/<dbname>
 
 ### VCAP_APPLICATION
 
+(optional) This variable can be used to override the uri used for the
+application.
+
     {"uris":["http://localhost:8080"]}
 
-Note that depending on your shell, you may need to escape the quotation marks when setting this variable at the command line:
-
-    export VCAP_APPLICATION={\"uris\":[\"http://localhost:8080\"]}
-
-## 
-To override the default VCAP_SERVICES that are configured for local development and CI.
-
 ### VCAP_SERVICES
+
+To override the default VCAP_SERVICES that are configured for local development and CI.
 
   [Local configuration](/server/environment-variables/local.json)
 


### PR DESCRIPTION
## Summary
Resolves failing [staging deploy](https://circleci.com/gh/18F/fs-open-forest-platform/3172).

The app on cloud.gov is failing to start because even though the DATABASE_URL is present, it is still trying to read the `database` service from user-provided services and crashing when it is not present. This changes the order of operations so that we only check for a user-provided service if the DATABASE_URL environment variable is not present, which should only happen in dev/test.

Also, update the wiki based on the env variable usage.

## Impacted Areas of the Site
N/A

## Optional Screenshots
N/A

## This pull request changes...
- [ ] how database configuration is read

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

