### PR TITLE
Add instructions to readme for handling Chromedriver/Chrome incompati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,9 +265,10 @@ OR
 - Find the appropriate version of [Chromedriver](http://chromedriver.chromium.org/downloads)
 - Navigate to `https://chromedriver.storage.googleapis.com/index.html?path=<version>/` where `<version>` is replaced by the Chromedriver version you want
 - Click on the link for your operating system to download the `.zip` file
-- Extract the executable
-- Copy both the `.zip` file and the executable to `frontend/node_modules/protractor/node_modules/webdriver-manager/selenium/`
-- Remove the other Chromedriver files in that directory
+- Extract the executable and copy it somewhere that makes sense to you, (ex: `~/chromedriver/`)
+- Ensure that the environment variable `OPEN_FOREST_CHROME_DRIVER` is set to the absolute path to the chromedriver executable above, either by exporting it in your profile or providing it when running the e2e tests. Ex. `OPEN_FOREST_CHROME_DRIVER="/Users/davidmcorwin/Downloads/chromedriver" npm run e2e`
+
+**Note: The output still shows that it downloads the latest chromedriver, but it will actually USE the one specified.**
 
 #### Testing WCAG2AA compliance with pa11y
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,17 @@ Add `--code-coverage` flag to print out code coverage statistics.
 
 Run `yarn run e2e` to execute the end-to-end tests via [Protractor](http://www.protractortest.org/).
 
+If you receive an error that Chromedriver requires a different version of Chrome than what is currently installed, most likely you have an older version of Chrome that is not compatible with the newest version of Chromedriver that will be installed by Protractor. You can:
+##### Update your version of [Chrome](https://www.google.com/chrome/)
+OR
+##### Download a specific version of Chromedriver that is compatible with your version of Chrome
+- Find the appropriate version of [Chromedriver](http://chromedriver.chromium.org/downloads)
+- Navigate to `https://chromedriver.storage.googleapis.com/index.html?path=<version>/` where `<version>` is replaced by the Chromedriver version you want
+- Click on the link for your operating system to download the `.zip` file
+- Extract the executable
+- Copy both the `.zip` file and the executable to `frontend/node_modules/protractor/node_modules/webdriver-manager/selenium/`
+- Remove the other Chromedriver files in that directory
+
 #### Testing WCAG2AA compliance with pa11y
 
 To run pa11y-ci with the single page angular app with pushstate enabled, you need to first build the static application, and then run the app from a server that supports pushstate. We are using superstatic as our server.
@@ -397,7 +408,7 @@ The server dependency is JSDOM is currently a fork to pass security vulnerabilit
 ## Known UX debt
 
 #### Scaling to include more permit types: Architecture to support purchasing or applying for multiple products per transaction
-The site’s architecture is not optimized to support users purchasing more than one product in a single transaction. It was built (1) with the understanding that tree cutter’s do not typically purchase permits for more than one forest and (2) for ease in modularly onboarding additional Forests, each with their own unique rules and guidelines, to sell Christmas tree permits. However, there is some evidence that users may want to purchase or apply for more than one of the permit types that the ePermits platform will eventually offer. Enabling users to purchase or apply for more than one permit type, including Christmas tree permits, online will require some rearchitecting. 
+The site’s architecture is not optimized to support users purchasing more than one product in a single transaction. It was built (1) with the understanding that tree cutter’s do not typically purchase permits for more than one forest and (2) for ease in modularly onboarding additional Forests, each with their own unique rules and guidelines, to sell Christmas tree permits. However, there is some evidence that users may want to purchase or apply for more than one of the permit types that the ePermits platform will eventually offer. Enabling users to purchase or apply for more than one permit type, including Christmas tree permits, online will require some rearchitecting.
 
 #### Scaling to include more Forests: Form controls to help users choose from a greater number of options
 The site was built to accommodate four pilot Forests. Scaling the application to include more Forests will require that a number of form controls be redesigned to support users in choosing their forest from greater than four options. Pages impacted:
@@ -407,7 +418,7 @@ The site was built to accommodate four pilot Forests. Scaling the application to
 - [Change cutting area dates*](https://forest-service-trees-staging.app.cloud.gov/admin/christmas-trees/district-dates)
 - [Change season dates*](https://forest-service-trees-staging.app.cloud.gov/admin/christmas-trees/season-dates)
 
-**This page will need to support users’ selection from a greater number of options only if the FS Product Owner and leadership decide that Forest administrators should have access to other Forests in the application, in addition to their own.* 
+**This page will need to support users’ selection from a greater number of options only if the FS Product Owner and leadership decide that Forest administrators should have access to other Forests in the application, in addition to their own.*
 
 The details of how these pages and form controls should be designed in order to support users selecting from a large number of Forests will require additional user research.
 

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ OR
 - Navigate to `https://chromedriver.storage.googleapis.com/index.html?path=<version>/` where `<version>` is replaced by the Chromedriver version you want
 - Click on the link for your operating system to download the `.zip` file
 - Extract the executable and copy it somewhere that makes sense to you, (ex: `~/chromedriver/`)
-- Ensure that the environment variable `OPEN_FOREST_CHROME_DRIVER` is set to the absolute path to the chromedriver executable above, either by exporting it in your profile or providing it when running the e2e tests. Ex. `OPEN_FOREST_CHROME_DRIVER="/Users/davidmcorwin/Downloads/chromedriver" npm run e2e`
+- Ensure that the environment variable `OPEN_FOREST_CHROME_DRIVER` is set to the absolute path to the chromedriver executable above, either by exporting it in your profile or providing it when running the e2e tests. Ex. `OPEN_FOREST_CHROME_DRIVER="/Users/<username>/Downloads/chromedriver" npm run e2e`
 
 **Note: The output still shows that it downloads the latest chromedriver, but it will actually USE the one specified.**
 

--- a/docs/development/environment-variables.md
+++ b/docs/development/environment-variables.md
@@ -8,7 +8,7 @@ These services are defined in the [Forest Service Cloud Migration Repository](ht
 
 To emulate the deployed environment variables we provide a list of local `VCAP_SERVICES` that will be automattically pulled in.
 
-## Local Development Enviroment Variables 
+## Local Development Enviroment Variables
 The following environment variables are required to run the application locally, in CI, or with docker:
 
 ### AWS_CONFIG
@@ -42,6 +42,10 @@ To override the default VCAP_SERVICES that are configured for local development 
   [Local configuration](/server/environment-variables/local.json)
 
   [Test configuration](/server/environment-variables/test.json)
+
+### OPEN_FOREST_CHROME_DRIVER
+
+(optional) Provide the absolute path to a specific chromedriver binary to use when running e2e tests **locally**.
 
 ## Deployed Environment variables
 The following environment variables are required for staging and production. In general, these will be set within cloud.gov as `user-provided-services`

--- a/frontend/development-configurations/protractor.conf.js
+++ b/frontend/development-configurations/protractor.conf.js
@@ -54,5 +54,6 @@ exports.config = {
     'app-xmas': '../e2e/authenticated/christmas-trees/xmas-tree-application.e2e-spec.ts',
     'unauthenticated': ['../e2e/unauthenticated/**/*.e2e-spec.ts'],
     'circle-e2e-split': []
-  }
+  },
+  chromeDriver: !isDocker && process.env['OPEN_FOREST_CHROME_DRIVER'],
 };


### PR DESCRIPTION
Add instructions to readme for handling Chromedriver/Chrome incompatibility

## Summary
Resolves Issue #504 

Add documentation around handling issues that may occur when using Protractor/chromedriver for ent-to-end testing of the application frontend.

A developer may get an error about chromedriver requiring a different version of chrome than what is installed.

## Impacted Areas of the Site
Internal documentation

## Optional Screenshots

## This pull request changes...
- [ ] readme.md

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
- [ ] Associated OpenAPI documentation has been updated

