### PR TITLE
improve controlling logging tests in xmas trees

### DIFF
--- a/server/src/services/util.es6
+++ b/server/src/services/util.es6
@@ -447,7 +447,7 @@ util.logControllerAction = (req, controller, applicationOrPermit) => {
   let role;
   let permitID;
   const subPath = controller.split('.');
-  if (subPath[0] === 'christmasTree'){
+  if (subPath[0] === 'christmasTreePermits'){
     userID = applicationOrPermit.emailAddress;
     role = 'PUBLIC';
     permitID = applicationOrPermit.permitId;

--- a/server/test/christmas-tree-permit-controllers.spec.es6
+++ b/server/test/christmas-tree-permit-controllers.spec.es6
@@ -23,7 +23,7 @@ let paygovToken;
 let tcsAppID;
 
 describe('christmas tree controller permit tests', () => {
-  describe.only('submit permit application mthood national forest', () => {
+  describe('submit permit application mthood national forest', () => {
     it('POST should return a 200 response when submitted to get pay.gov token', done => {
       const permitApplication = christmasTreePermitApplicationFactory.create();
       permitApplication.forestId = 3;

--- a/server/test/christmas-tree-permit-controllers.spec.es6
+++ b/server/test/christmas-tree-permit-controllers.spec.es6
@@ -7,6 +7,7 @@ const request = require('supertest');
 const emailSendStub = require('./common.es6');
 const sinon = require('sinon');
 const permitSvgService = require('../src/services/christmas-trees-permit-svg-util.es6');
+const logger = require('../src/services/logger.es6');
 
 const christmasTreePermitApplicationFactory = require('./data/christmas-trees-permit-application-factory.es6');
 const christmasTreePermitFactory = require('./data/christmas-trees-permit-factory.es6');
@@ -22,7 +23,7 @@ let paygovToken;
 let tcsAppID;
 
 describe('christmas tree controller permit tests', () => {
-  describe('submit permit application mthood national forest', () => {
+  describe.only('submit permit application mthood national forest', () => {
     it('POST should return a 200 response when submitted to get pay.gov token', done => {
       const permitApplication = christmasTreePermitApplicationFactory.create();
       permitApplication.forestId = 3;
@@ -48,6 +49,7 @@ describe('christmas tree controller permit tests', () => {
         },
         vcapConstants.PERMIT_SECRET
       );
+
       request(server)
         .put(`/forests/christmas-trees/permits?t=${token}`)
         .send(completeApplication)
@@ -61,9 +63,18 @@ describe('christmas tree controller permit tests', () => {
         },
         vcapConstants.PERMIT_SECRET
       );
+
+      const loggerSpy = sinon.spy(logger, 'info');
       request(server)
         .get(`/forests/christmas-trees/permits/${permitId}?t=${token}`)
-        .set('Accept', 'application/json')
+        .set('Accept', /json/)
+        .expect(res => {
+          expect(res.body.firstName).to.equal('fName');
+          expect(loggerSpy.called).to.be.true;
+          const loggingStatement = `CONTROLLER: GET:christmasTreePermits.getOnePermit \
+by ${res.body.emailAddress}:PUBLIC for ${res.body.permitId} at`;
+          expect(loggerSpy.calledWith(sinon.match(loggingStatement))).to.be.true;
+        })
         .expect(200, done);
     });
     it('GET should return a 404 response when requesting an invalid permit', done => {
@@ -425,7 +436,7 @@ describe('christmas tree controller permit tests', () => {
       request(server)
         .get(`/forests/christmas-trees/permits/${permitId}/print?rules=true`)
         .expect('Content-Type', /json/)
-        .expect(function(res) {
+        .expect((res) => {
           expect(res.body).to.include.all.keys('result');
         })
         .expect(200, done);


### PR DESCRIPTION
## Summary
Resolves Issue #[483](https://github.com/18F/fs-open-forest-platform/issues/483)

*Describe the pull request here, including any supplemental information needed to understand it.*

## Impacted Areas of the Site
- tests for server logging

## Optional Screenshots


## This pull request changes...
- [ ] better capture logged controlling statement in test

## This pull request is ready to merge when...
- [ ] Tests have been updated (and all tests are passing)
- [ ] This code has been reviewed by someone other than the original author
- [ ] The change has been documented
  - [ ] Associated OpenAPI documentation has been updated

