### PR TITLE
Add 30 day exclusion for SNYK-JS-MARKED-73637

### DIFF
--- a/frontend/.snyk
+++ b/frontend/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.3
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-MARKED-73637:
+    - ngx-md > marked:
+        reason: No current remediation and requires internal attack vector.
+        expires: '2019-03-06T22:39:07.646Z'
+patch: {}

--- a/server/.snyk
+++ b/server/.snyk
@@ -6,4 +6,7 @@ ignore:
     - ngx-md > marked:
         reason: No current remediation and requires internal attack vector.
         expires: '2019-03-06T22:39:07.646Z'
+      jsdoc > marked:
+        reason: No current remediation and requires internal attack vector.
+        expires: '2019-03-06T23:25:03.850Z'
 patch: {}

--- a/server/.snyk
+++ b/server/.snyk
@@ -1,0 +1,9 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.3
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-MARKED-73637:
+    - ngx-md > marked:
+        reason: No current remediation and requires internal attack vector.
+        expires: '2019-03-06T22:39:07.646Z'
+patch: {}


### PR DESCRIPTION
## Summary
Addresses Issue #536

Please note if fully resolves the issue per the acceptance criteria: Y

Add 30 day exclusion for SNYK-JS-MARKED-73637 as there is currently no remediation and there is a low probability of attack since it would have to be internal.

## This pull request changes...
- [x] The snyk configuration

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
