### PR TITLE
Use hashed asset filenames

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,9 +4,8 @@
   "license": "MIT",
   "scripts": {
     "build": "ng build",
-    "dist": "ng build --prod --configuration=production",
-    "dist-trees": "ng build --configuration=trees",
-    "dist-prod": "ng build --configuration=production",
+    "dist-trees": "ng build --prod --output-hashing=all --configuration=trees",
+    "dist-prod": "ng build --prod --output-hashing=all --configuration=production",
     "docs": "typedoc --out ./src/assets/typedoc --exclude '**/*.spec.ts' ./src/ --module commonjs",
     "e2e:cidkr": "ng e2e --port=4200 --protractor-config ./development-configurations/protractor.conf.js --suite=docker-smoke-test",
     "e2e:xmas": "ng e2e --port=4200 --protractor-config ./development-configurations/protractor.conf.js --suite=app-xmas",


### PR DESCRIPTION
- Use --prod and --output-hashing=all flags when building for staging and prod envs
- Remove unused `dist` task

## Summary
Addresses Issue #522 

Please note if fully resolves the issue per the acceptance criteria: Y

Use unique filenames for assets so caches are busted when assets change.

## Impacted Areas of the Site
- Deployment

## Optional Screenshots

## This pull request changes...
- [x] asset file names

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [] Server actions captured by logs (manual)
- [] Documentation / readme.md updated (manual)
- [] API docs updated if need (manual)
- [] JSDocs updated (manual)
- [] Docker updated if needed (manual)
- [x] This code has been reviewed by someone other than the original author
