### PR TITLE
Modify existing permit object instead of creating a new `object` from it

### DIFF
--- a/server/src/services/permit-service.es6
+++ b/server/src/services/permit-service.es6
@@ -98,12 +98,13 @@ permitService.generateRulesAndEmail = permit => permitSvgService.generatePermitS
       permit.permitId,
       false
     );
-    const updatedPermit = { ...permit, permitUrl };
+    // eslint-disable-next-line no-param-reassign
+    permit.permitUrl = permitUrl;
     const rulesText = htmlToText.fromString(rulesHtml, {
       wordwrap: 130,
       ignoreImage: true
     });
-    return permitService.sendEmail(updatedPermit, permitPng, rulesHtml, rulesText);
+    return permitService.sendEmail(permit, permitPng, rulesHtml, rulesText);
   });
 
 /**


### PR DESCRIPTION
## Summary
I noticed this when testing the emails, but previous commits replaced an object assignment on a Sequelize object with a copy, and this caused the fields to not be available when creating the email.

## Impacted Areas of the Site
- Permit emails

## Optional Screenshots

## This pull request changes...
- [x] Restore sending of emails for purchased permits.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [] Is connected to its original issue via zenhub 👇
- [] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [] Server actions captured by logs (manual)
- [] Documentation / readme.md updated (manual)
- [] API docs updated if need (manual)
- [] JSDocs updated (manual)
- [] Docker updated if needed (manual)
- [x] This code has been reviewed by someone other than the original author
