### PR TITLE
Only call `gas` if it is available

### DIFF
--- a/frontend/src/app/_services/google-analytics.service.ts
+++ b/frontend/src/app/_services/google-analytics.service.ts
@@ -8,6 +8,12 @@ export class GoogleAnalyticsService {
   constructor(router: Router) {
     router.events.subscribe(event => {
       if (event instanceof NavigationEnd) {
+
+        // `gas` may not be available if blocked by an ad blocker
+        if (typeof gas === 'undefined') {
+          return;
+        }
+
         gas('send', 'pageview', event.url, document.title);
       }
     });


### PR DESCRIPTION
## Summary
Addresses Issue #578 

Please note if fully resolves the issue per the acceptance criteria: Y

Only report analytics events if analytics is allowed to load on the page.

## Impacted Areas of the Site
- Analytics/everything if analytics is blocked

## Optional Screenshots

## This pull request changes...
- [x] Site is available if analytics is blocked

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [] Server actions captured by logs (manual)
- [] Documentation / readme.md updated (manual)
- [] API docs updated if need (manual)
- [] JSDocs updated (manual)
- [] Docker updated if needed (manual)
- [x] This code has been reviewed by someone other than the original author
