### PR TITLE
Provide contents of report as third argument to `snyk-email`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -328,7 +328,7 @@ jobs:
             export DATE_STRING=`date +"%m-%d-%Y-%H"`
             export SNYK_REPORT=snyk-${CIRCLE_PROJECT_REPONAME}-${DATE_STRING}.csv
             cd server
-            cf run-task open-forest-platform-api "npm run snyk-email -- ${DATE_STRING} ../${SNYK_DIR}/${SNYK_REPORT}"
+            cf run-task open-forest-platform-api "npm run snyk-email -- ${DATE_STRING} ${SNYK_REPORT} '`cat ../${SNYK_DIR}/${SNYK_REPORT}`'"
 
   recycle-production:
     docker:

--- a/server/scripts/email-snyk-report.js
+++ b/server/scripts/email-snyk-report.js
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-const path = require('path');
 const nodemailer = require('nodemailer');
 const {
   SMTP_HOST,
@@ -9,7 +8,7 @@ const {
   SNYK_RECIPIENTS
 } = require('../src/vcap-constants.es6');
 
-function emailSnykReport(reportDate, reportPath) {
+function emailSnykReport(reportDate, reportFilename, reportContent) {
   const smtpConfig = {
     host: SMTP_HOST,
     port: SMTP_PORT || 587,
@@ -32,7 +31,10 @@ function emailSnykReport(reportDate, reportPath) {
     from: `"Open Forest Security Monitoring" <${SMTP_USERNAME}>`,
     to: SNYK_RECIPIENTS,
     subject: `Snyk Report for ${reportDate}`,
-    attachments: [{ path: path.resolve(reportPath) }],
+    attachments: [{
+      filename: reportFilename,
+      content: reportContent
+    }],
     text: `
       See attached Snyk report for ${reportDate}.
 
@@ -44,6 +46,7 @@ function emailSnykReport(reportDate, reportPath) {
   nodemailer.createTransport(smtpConfig).sendMail(mailOptions, (error) => {
     if (error) {
       console.error('NODE_MAILER_SMTP_ERROR', error);
+      process.exit(1);
     } else {
       console.log('Snyk report successfully sent');
     }


### PR DESCRIPTION
## Summary
Addresses Issue #572 

Please note if fully resolves the issue per the acceptance criteria: Y

We can can only send emails from Cloud.gov since the IPs are whitelisted with our email provider. However, we are generating the Snyk report in CircleCI which means the file itself is not available in the Cloud.gov environment, and the first iteration was passing the file path as an argument so this did not work. Here, we pass the CONTENTS of the file as an additional argument to `snyk-email` so it no longer relies on a file existing on the file system.

To be tested in staging.

## Impacted Areas of the Site
- CI

## This pull request changes...
- [x] nightly snyk process

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
