### PR TITLE
489 verify email

### DIFF
--- a/frontend/e2e/authenticated/christmas-trees/christmas-tree-form.po.ts
+++ b/frontend/e2e/authenticated/christmas-trees/christmas-tree-form.po.ts
@@ -16,14 +16,21 @@ export class ChristmasTreeForm {
   lastNameError() {
     return element(by.css('span[id$="primary-permit-holder-last-name-error"]'));
   }
-
   email() {
     return element(by.css('input[id$="email"]'));
   }
   emailError() {
     return element(by.css('span[id$="email-error"]'));
   }
-
+  emailConfirmation() {
+    return element(by.css('input[id$="email-confirmation"]'));
+  }
+  emailConfirmationError() {
+    return element(by.css('span[id$="email-confirmation-error"]'));
+  }
+  emailGroupError() {
+    return element(by.css('span[id$="email-group-error"]'));
+  }
   treeAmount() {
     return element(by.css('input[id$="quantity"]'));
   }
@@ -67,6 +74,7 @@ export class ChristmasTreeForm {
     element(by.css('.primary-permit-holder-first-name')).sendKeys('Sarah');
     element(by.css('.primary-permit-holder-last-name')).sendKeys('Bell');
     element(by.id('email')).sendKeys('msdf@noemail.com');
+    element(by.id('email-confirmation')).sendKeys('msdf@noemail.com');
     element(by.id('quantity')).sendKeys('2');
   }
 
@@ -83,6 +91,7 @@ export class ChristmasTreeForm {
     element(by.css('.primary-permit-holder-first-name')).sendKeys(first);
     element(by.css('.primary-permit-holder-last-name')).sendKeys(last);
     element(by.id('email')).sendKeys('msdf@noemail.com');
+    element(by.id('email-confirmation')).sendKeys('msdf@noemail.com');
     element(by.id('quantity')).sendKeys('2');
     this.submit().click();
     this.rulesAccepted().click();

--- a/frontend/e2e/authenticated/christmas-trees/xmas-tree-application.e2e-spec.ts
+++ b/frontend/e2e/authenticated/christmas-trees/xmas-tree-application.e2e-spec.ts
@@ -64,6 +64,21 @@ describe('Apply for a Christmas tree permit', () => {
       expect<any>(christmasTreeForm.emailError().isPresent()).toBeFalsy();
     });
 
+    it('should display an error for an invalid email address confirmation', () => {
+      expect<any>(christmasTreeForm.emailConfirmation().isDisplayed()).toBeTruthy();
+      christmasTreeForm.email().clear();
+      christmasTreeForm.email().sendKeys('aaaaaa@aaa');
+      christmasTreeForm.emailConfirmation().sendKeys('aaaaaa');
+      expect<any>(christmasTreeForm.emailConfirmationError().isDisplayed()).toBeTruthy();
+      expect<any>(christmasTreeForm.emailGroupError().isPresent()).toBeFalsy();
+      christmasTreeForm.emailConfirmation().sendKeys('@a');
+      expect<any>(christmasTreeForm.emailConfirmationError().isPresent()).toBeFalsy();
+      expect<any>(christmasTreeForm.emailGroupError().isPresent()).toBeTruthy();
+      christmasTreeForm.emailConfirmation().sendKeys('aa');
+      expect<any>(christmasTreeForm.emailConfirmationError().isPresent()).toBeFalsy();
+      expect<any>(christmasTreeForm.emailGroupError().isPresent()).toBeFalsy();
+    });
+
     it('should display an error for an invalid tree amount', () => {
       expect<any>(christmasTreeForm.treeAmount().isDisplayed()).toBeTruthy();
       christmasTreeForm.treeAmount().clear();

--- a/frontend/src/app/application-forms/applications.module.ts
+++ b/frontend/src/app/application-forms/applications.module.ts
@@ -13,6 +13,7 @@ import { ExperienceComponent } from './fields/experience.component';
 import { DateTimeRangeComponent } from './fields/date-time-range.component';
 import { DateTimeRangeService } from './_services/date-time-range.service';
 import { EmailComponent } from './fields/email.component';
+import { EmailConfirmationComponent } from './fields/email-confirmation.component';
 import { FaxComponent } from './fields/fax.component';
 import { FileUploadModule } from 'ng2-file-upload';
 import { FileUploadComponent } from './fields/file-upload.component';
@@ -44,6 +45,7 @@ import { TreePermitRulesComponent } from './tree-application-form/tree-permit-ru
     ClientChargesComponent,
     DateTimeRangeComponent,
     EmailComponent,
+    EmailConfirmationComponent,
     ExperienceComponent,
     FaxComponent,
     FileUploadComponent,
@@ -72,6 +74,7 @@ import { TreePermitRulesComponent } from './tree-application-form/tree-permit-ru
     ClientChargesComponent,
     DateTimeRangeComponent,
     EmailComponent,
+    EmailConfirmationComponent,
     ExperienceComponent,
     FaxComponent,
     FileUploadComponent,

--- a/frontend/src/app/application-forms/fields/email-confirmation.component.html
+++ b/frontend/src/app/application-forms/fields/email-confirmation.component.html
@@ -1,0 +1,10 @@
+<ng-container [formGroup]="applicantInfo">
+  <label class="usa-input" for='email-confirmation' id="email-confirmation-label">Email address confirmation</label>
+  <span id="email-confirmation-hint-text" class="help-text usa-form-hint"><span *ngIf="hintText">{{hintText}}</span></span>
+  <input id="email-confirmation" type="email" pattern="(^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$)" formControlName="emailAddressConfirmation" aria-required="true"
+    [attr.aria-labelledby]="afs.labelledBy(applicantInfo.controls.emailAddressConfirmation, 'email-confirmation-label email-confirmation-hint-text', 'email-confirmation-error')"
+    [attr.aria-invalid]="afs.hasError(applicantInfo.controls.emailAddressConfirmation)"
+  />
+  <app-error-message fieldId="email-confirmation-error" name="Email address confirmation" [control]="applicantInfo.controls.emailAddressConfirmation"></app-error-message>
+  <app-error-message *ngIf="afs.hasError(applicantInfo.controls.emailAddressConfirmation) === 'false'" fieldId="email-group-error" name="Email group" [control]="applicantInfo"></app-error-message>
+</ng-container>

--- a/frontend/src/app/application-forms/fields/email-confirmation.component.spec.ts
+++ b/frontend/src/app/application-forms/fields/email-confirmation.component.spec.ts
@@ -1,0 +1,67 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { AbstractControl, FormBuilder, Validators, FormControl } from '@angular/forms';
+import { EmailConfirmationComponent } from './email-confirmation.component';
+import { alphanumericValidator } from '../validators/alphanumeric-validation';
+import { emailConfirmationValidator } from '../validators/email-confirmation-validation';
+import { ApplicationFieldsService } from '../_services/application-fields.service';
+
+describe('Email Confirmation Component', () => {
+  let component: EmailConfirmationComponent;
+  let fixture: ComponentFixture<EmailConfirmationComponent>;
+  let formBuilder: FormBuilder;
+  let emailField: AbstractControl;
+  let confirmationField: AbstractControl;
+
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        declarations: [EmailConfirmationComponent],
+        providers: [FormBuilder, ApplicationFieldsService],
+        schemas: [NO_ERRORS_SCHEMA]
+      }).compileComponents();
+      formBuilder = new FormBuilder();
+      fixture = TestBed.createComponent(EmailConfirmationComponent);
+      component = fixture.debugElement.componentInstance;
+      component.applicantInfo = formBuilder.group({
+        emailAddress: ['', [Validators.required, Validators.email, alphanumericValidator()]],
+        emailAddressConfirmation: ['', [Validators.required, Validators.email, alphanumericValidator()]]
+      }, { validators: emailConfirmationValidator('emailAddress', 'emailAddressConfirmation') });
+      fixture.detectChanges();
+
+      emailField = component.applicantInfo.controls.emailAddress;
+      confirmationField = component.applicantInfo.controls.emailAddressConfirmation;
+
+      emailField.markAsTouched();
+      confirmationField.markAsTouched();
+    })
+  );
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('is invalid when value is not an email address', () => {
+    confirmationField.setValue('test');
+    expect(confirmationField.valid).toBeFalsy();
+  });
+
+  it('is valid when value is an email address', () => {
+    confirmationField.setValue('test@test.com');
+    expect(confirmationField.valid).toBeTruthy();
+  });
+
+  it('makes the form invalid when value is an email address, but does not match email control', () => {
+    emailField.setValue('test@test.com');
+    confirmationField.setValue('test2@test.com');
+
+    expect(component.applicantInfo.valid).toBeFalsy();
+  });
+
+  it('makes the form valid when value is an email address and matches email control', () => {
+    emailField.setValue('test@test.com');
+    confirmationField.setValue('test@test.com');
+
+    expect(component.applicantInfo.valid).toBeTruthy();
+  });
+});

--- a/frontend/src/app/application-forms/fields/email-confirmation.component.ts
+++ b/frontend/src/app/application-forms/fields/email-confirmation.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { ApplicationFieldsService } from '../_services/application-fields.service';
+
+@Component({
+  selector: 'app-email-confirmation',
+  templateUrl: './email-confirmation.component.html'
+})
+export class EmailConfirmationComponent {
+  @Input() applicantInfo: FormGroup;
+  @Input() hintText: string;
+  constructor(public afs: ApplicationFieldsService) {}
+}

--- a/frontend/src/app/application-forms/fields/email.component.html
+++ b/frontend/src/app/application-forms/fields/email.component.html
@@ -6,12 +6,4 @@
     [attr.aria-invalid]="afs.hasError(applicantInfo.controls.emailAddress)"
   />
   <app-error-message fieldId="email-error" name="Email address" [control]="applicantInfo.controls.emailAddress"></app-error-message>
-  <label class="usa-input" for='email-confirmation' id="email-confirmation-label">Email address confirmation</label>
-  <span id="email-confirmation-hint-text" class="help-text usa-form-hint"><span>Please verify your email address</span></span>
-  <input id="email-confirmation" type="email" pattern="(^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$)" formControlName="emailAddressConfirmation" aria-required="true"
-    [attr.aria-labelledby]="afs.labelledBy(applicantInfo.controls.emailAddressConfirmation, 'email-confirmation-label email-confirmation-hint-text', 'email-confirmation-error')"
-    [attr.aria-invalid]="afs.hasError(applicantInfo.controls.emailAddressConfirmation) || applicationInfo.errors.emailConfirmationRequirement === true"
-  />
-  <app-error-message fieldId="email-confirmation-error" name="Email address confirmation" [control]="applicantInfo.controls.emailAddressConfirmation"></app-error-message>
-  <app-error-message fieldId="email-group-error" name="Email group" [control]="applicantInfo"></app-error-message>
 </ng-container>

--- a/frontend/src/app/application-forms/fields/email.component.html
+++ b/frontend/src/app/application-forms/fields/email.component.html
@@ -6,4 +6,12 @@
     [attr.aria-invalid]="afs.hasError(applicantInfo.controls.emailAddress)"
   />
   <app-error-message fieldId="email-error" name="Email address" [control]="applicantInfo.controls.emailAddress"></app-error-message>
+  <label class="usa-input" for='email-confirmation' id="email-confirmation-label">Email address confirmation</label>
+  <span id="email-confirmation-hint-text" class="help-text usa-form-hint"><span>Please verify your email address</span></span>
+  <input id="email-confirmation" type="email" pattern="(^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$)" formControlName="emailAddressConfirmation" aria-required="true"
+    [attr.aria-labelledby]="afs.labelledBy(applicantInfo.controls.emailAddressConfirmation, 'email-confirmation-label email-confirmation-hint-text', 'email-confirmation-error')"
+    [attr.aria-invalid]="afs.hasError(applicantInfo.controls.emailAddressConfirmation) || applicationInfo.errors.emailConfirmationRequirement === true"
+  />
+  <app-error-message fieldId="email-confirmation-error" name="Email address confirmation" [control]="applicantInfo.controls.emailAddressConfirmation"></app-error-message>
+  <app-error-message fieldId="email-group-error" name="Email group" [control]="applicantInfo"></app-error-message>
 </ng-container>

--- a/frontend/src/app/application-forms/tree-application-form/tree-application-form.component.html
+++ b/frontend/src/app/application-forms/tree-application-form/tree-application-form.component.html
@@ -24,7 +24,6 @@
           Christmas trees cost ${{costPerTree}} each, and a household is allowed to cut up to {{maxNumberOfTrees}} trees.
           All permits are non-refundable.
         </p>
-        <p><b>Your permit must be printed to be valid and cannot be stored on a mobile device.</b></p>
         <div id="form-errors"
           *ngIf="(submitted && !applicationForm.valid)"
           class="usa-alert usa-alert-error" aria-live="assertive" aria-hidden="false" role="alert">
@@ -35,9 +34,16 @@
         </div>
 
       <fieldset>
-        <p>All form fields are required unless otherwise noted.</p>
+        <legend>Permit information</legend>
+        <app-quantity [parentGroup]="applicationForm" label="Number of Christmas trees" hintText="Up to {{maxNumberOfTrees}} trees allowed per household."></app-quantity>
+        <label class="margin-top-2 total-cost">Total cost for Christmas tree permit: <span id="total-cost" class="margin-left-1">${{applicationForm.controls.totalCost.value}}</span></label>
+      </fieldset>
+      <fieldset>
         <legend>Permit holder information</legend>
+        <p>All form fields are required unless otherwise noted.</p>
         <p>The permit holder’s name is on the permit. Permit holder must be present at time of tree cutting and transport.</p>
+        <app-permit-holder-name [applicantInfo]="applicationForm"></app-permit-holder-name>
+        <app-email [applicantInfo]="applicationForm" hintText="Your permit will be sent to the email address you provide and must be printed. Please enter your email address so that your permit can be emailed to you."></app-email>
         <div class="trees-applications-pii-accept-checkbox-container">
           <input id="accept-pii" type="checkbox" formControlName='acceptPII' name="accept-pii" required>
           <label id='accept-pii-label' for="accept-pii">By checking this box, I acknowledge that Open Forest will collect and store my name and email address. For more
@@ -45,10 +51,6 @@
           <app-error-message fieldId="accept-rules-error" name="To purchase a tree permit, consenting to our collection of your name and email"
             [control]="applicationForm.controls.acceptPII"></app-error-message>
         </div>
-        <app-permit-holder-name [applicantInfo]="applicationForm"></app-permit-holder-name>
-        <app-email [applicantInfo]="applicationForm" hintText="Your permit will be sent to the email address you provide and must be printed. Please enter your email address so that your permit can be emailed to you."></app-email>
-        <app-quantity [parentGroup]="applicationForm" label="Number of Christmas trees" hintText="Up to {{maxNumberOfTrees}} trees allowed per household."></app-quantity>
-        <label class="margin-top-2 total-cost">Total cost for Christmas tree permit: <span id="total-cost" class="margin-left-1">${{applicationForm.controls.totalCost.value}}</span></label>
       </fieldset>
 
         <button id="application-next" class="usa-button-primary usa-button-big" type="submit">Next</button>

--- a/frontend/src/app/application-forms/tree-application-form/tree-application-form.component.html
+++ b/frontend/src/app/application-forms/tree-application-form/tree-application-form.component.html
@@ -44,6 +44,7 @@
         <p>The permit holder’s name is on the permit. Permit holder must be present at time of tree cutting and transport.</p>
         <app-permit-holder-name [applicantInfo]="applicationForm"></app-permit-holder-name>
         <app-email [applicantInfo]="applicationForm" hintText="Your permit will be sent to the email address you provide and must be printed. Please enter your email address so that your permit can be emailed to you."></app-email>
+        <app-email-confirmation [applicantInfo]="applicationForm" hintText="Please verify your email address"></app-email-confirmation>
         <div class="trees-applications-pii-accept-checkbox-container">
           <input id="accept-pii" type="checkbox" formControlName='acceptPII' name="accept-pii" required>
           <label id='accept-pii-label' for="accept-pii">By checking this box, I acknowledge that Open Forest will collect and store my name and email address. For more

--- a/frontend/src/app/application-forms/tree-application-form/tree-application-form.component.ts
+++ b/frontend/src/app/application-forms/tree-application-form/tree-application-form.component.ts
@@ -5,6 +5,7 @@ import { alphanumericValidator } from '../validators/alphanumeric-validation';
 import { FormBuilder, FormGroup, Validators, FormControl } from '@angular/forms';
 import { ActivatedRoute, Params, Router } from '@angular/router';
 import { currencyValidator } from '../validators/currency-validation';
+import { emailConfirmationValidator } from '../validators/email-confirmation-validation';
 import { lessThanOrEqualValidator } from '../validators/less-than-or-equal-validation';
 import { ChristmasTreesInfoService } from '../../trees/_services/christmas-trees-info.service';
 import { ApplicationFieldsService } from '../_services/application-fields.service';
@@ -85,9 +86,10 @@ export class TreeApplicationFormComponent implements OnInit {
       firstName: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(255)]],
       lastName: ['', [Validators.required, alphanumericValidator(), Validators.maxLength(255)]],
       emailAddress: ['', [Validators.required, Validators.email, alphanumericValidator(), Validators.maxLength(255)]],
+      emailAddressConfirmation: ['', [Validators.required, Validators.email, alphanumericValidator(), Validators.maxLength(255)]],
       quantity: ['', [Validators.required, Validators.min(1), Validators.max(maxNumTrees)]],
       totalCost: [0, [Validators.required, currencyValidator()]]
-    });
+    }, { validators: emailConfirmationValidator('emailAddress', 'emailAddressConfirmation') });
   }
 
   /**

--- a/frontend/src/app/application-forms/validators/email-confirmation-validation.ts
+++ b/frontend/src/app/application-forms/validators/email-confirmation-validation.ts
@@ -1,0 +1,9 @@
+import { AbstractControl, FormGroup, ValidatorFn, ValidationErrors } from '@angular/forms';
+
+export function emailConfirmationValidator(emailControl: string, confirmControl: string): ValidatorFn {
+  return (control: FormGroup): ValidationErrors | null => {
+    const email = control.get(emailControl);
+    const confirm = control.get(confirmControl);
+    return email && confirm && email.value !== confirm.value ? { 'emailConfirmationRequirement': true } : null;
+  };
+}

--- a/frontend/src/app/application-forms/validators/email-confirmation-validation.ts
+++ b/frontend/src/app/application-forms/validators/email-confirmation-validation.ts
@@ -1,4 +1,4 @@
-import { AbstractControl, FormGroup, ValidatorFn, ValidationErrors } from '@angular/forms';
+import { FormGroup, ValidatorFn, ValidationErrors } from '@angular/forms';
 
 export function emailConfirmationValidator(emailControl: string, confirmControl: string): ValidatorFn {
   return (control: FormGroup): ValidationErrors | null => {

--- a/frontend/src/app/application-forms/validators/error-message.component.ts
+++ b/frontend/src/app/application-forms/validators/error-message.component.ts
@@ -98,6 +98,10 @@ export class ErrorMessageComponent {
     return `It appears you have entered fewer than 75 total attendees. For fewer than 75, you do not need a permit.`;
   }
 
+  emailConfirmationRequirement(errors) {
+    return `Email confirmation does not match email.`;
+  }
+
   pattern(errors) {
     let result = '';
 

--- a/server/.snyk
+++ b/server/.snyk
@@ -33,4 +33,8 @@ ignore:
     - jsdoc > marked:
         reason: 'Medium severity, no remediation available.'
         expires: '2019-05-08T15:56:53.989Z'
+  SNYK-JS-SEQUELIZE-174167:
+    - sequelize:
+        reason: 'Remediation will be handled in issue #598'
+        expires: '2019-05-12T20:06:12.781Z'
 patch: {}


### PR DESCRIPTION
## Summary
Addresses Issue #489 

Please note if fully resolves the issue per the acceptance criteria: Y

Reorders some content and adds an email confirmation field to the xmas trees application form.
### Entire screen
![screencapture-localhost-4200-christmas-trees-forests-arp-applications-2019-04-11-14_36_44](https://user-images.githubusercontent.com/6662371/55994713-504b2680-5c67-11e9-94af-351c7b560e0a.png)

### Pristine email address fields
<img width="519" alt="Screen Shot 2019-04-11 at 2 30 28 PM" src="https://user-images.githubusercontent.com/6662371/55994421-7c19dc80-5c66-11e9-837a-94212bb16c12.png">

### Invalid email address
<img width="507" alt="Screen Shot 2019-04-11 at 2 30 36 PM" src="https://user-images.githubusercontent.com/6662371/55994420-7b814600-5c66-11e9-942b-10daadaaeb3a.png">

### Email address doesn't match
<img width="496" alt="Screen Shot 2019-04-11 at 2 31 03 PM" src="https://user-images.githubusercontent.com/6662371/55994419-7b814600-5c66-11e9-9756-6662fd836942.png">

### Notes
- @lisaredux There may be slight differences when compared to the mock up. In particular, there is an extra heading of "Permit Information" due to accessibility concerns abour forms, fieldsets and legends.
- The error messages are configured such that the "Email confirmation does not match email" error is only displayed if there are no other errors.
- Whilte the form is invalid, the email confirmation field does NOT reflect an invalid state when the email addresses do not match, thus the field will not have a red border when this is the only validation failure. @mtlaney is this something we can fix?

## Impacted Areas of the Site
- Xmas Trees Permit Application

## Optional Screenshots

## This pull request changes...
- [ ] order of form fields and headers
- [ ] additional email confirmation field with expected form validations

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] Server actions captured by logs (manual)
- [x] Documentation / readme.md updated (manual)
- [x] API docs updated if need (manual)
- [x] JSDocs updated (manual)
- [x] Docker updated if needed (manual)
- [ ] This code has been reviewed by someone other than the original author
