### PR TITLE
Use old callback url in SAML assertion

### DIFF
--- a/server/src/auth/usda-eauth.es6
+++ b/server/src/auth/usda-eauth.es6
@@ -10,12 +10,10 @@ const logger = require('../services/logger.es6');
 
 const eAuth = {};
 
-eAuth.callbackPath = '/auth/admin/callback';
-
 // Instantiate the passport SamlStrategy
 eAuth.strategy = () => new SamlStrategy(
   {
-    path: vcapConstants.BASE_URL + eAuth.callbackPath,
+    path: `${vcapConstants.BASE_URL}/auth/usda-eauth/saml/callback`,
     entryPoint: `${vcapConstants.EAUTH_ENTRY_POINT}?SPID=${vcapConstants.EAUTH_ISSUER}`,
     issuer: vcapConstants.EAUTH_ISSUER,
     privateCert: vcapConstants.EAUTH_PRIVATE_KEY,


### PR DESCRIPTION
## Summary
Addresses Issue #613 Staging EAuth issues.

This is the last thing I can think of, having a separate issue in dev so I can't test.

Please note if fully resolves the issue per the acceptance criteria: Y/N

## Impacted Areas of the Site
- EAuth authentication

## This pull request changes...
- [x] restores EAuth authentication

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [] Server actions captured by logs (manual)
- [] Documentation / readme.md updated (manual)
- [] API docs updated if need (manual)
- [] JSDocs updated (manual)
- [] Docker updated if needed (manual)
- [x] This code has been reviewed by someone other than the original author
