### PR TITLE
Revert redirect URIs until Login.gov configuration can be updated

### DIFF
--- a/server/src/auth/login-gov.es6
+++ b/server/src/auth/login-gov.es6
@@ -11,7 +11,7 @@ const util = require('../services/util.es6');
 const vcapConstants = require('../vcap-constants.es6');
 const logger = require('../services/logger.es6');
 
-const POST_LOGOUT_REDIRECT_URI = encodeURIComponent(`${vcapConstants.BASE_URL}/auth/logout`);
+const POST_LOGOUT_REDIRECT_URI = encodeURIComponent(`${vcapConstants.BASE_URL}/auth/login-gov/openid/logout`);
 
 const loginGov = {};
 
@@ -30,7 +30,7 @@ loginGov.params = {
   acr_values: 'http://idmanagement.gov/ns/assurance/loa/1',
   nonce: util.getRandomString(32),
   prompt: 'select_account',
-  redirect_uri: `${vcapConstants.BASE_URL}/auth/public/callback`,
+  redirect_uri: `${vcapConstants.BASE_URL}/auth/login-gov/openid/callback`,
   response_type: 'code',
   scope: 'openid email',
   state: util.getRandomString(32)

--- a/server/src/routers/auth.es6
+++ b/server/src/routers/auth.es6
@@ -11,6 +11,10 @@ const middleware = require('../services/middleware.es6');
 
 const router = express.Router();
 
+const SCRIPT_REDIRECT = (_req, res) => res.send(`<script>window.location = '${INTAKE_CLIENT_BASE_URL}/logged-in'</script>`);
+const publicPassport = passport.authenticate('public', { failureRedirect: INTAKE_CLIENT_BASE_URL });
+const adminPassport = passport.authenticate('admin', { failureRedirect: INTAKE_CLIENT_BASE_URL });
+
 /* GET the universal passport user. */
 router.get('/user', middleware.checkPermissions, passportConfig.getPassportUser);
 
@@ -19,29 +23,17 @@ router.get('/logout', passportConfig.logout);
 
 /* Public user authentication */
 router.get('/public/login', passport.authenticate('public'));
-router.get('/public/callback',
-  passport.authenticate('public', { failureRedirect: INTAKE_CLIENT_BASE_URL }),
-  (_req, res) => res.send(`<script>window.location = '${INTAKE_CLIENT_BASE_URL}/logged-in'</script>`));
-
-router.post('/public/callback',
-  passport.authenticate('public', { failureRedirect: INTAKE_CLIENT_BASE_URL }),
-  (_req, res) => res.send(`<script>window.location = '${INTAKE_CLIENT_BASE_URL}/logged-in'</script>`));
+router.get('/public/callback', publicPassport, SCRIPT_REDIRECT);
+router.post('/public/callback', publicPassport, SCRIPT_REDIRECT);
+// TODO - eventually remove
+router.get('/login-gov/openid/callback', publicPassport, SCRIPT_REDIRECT);
+router.post('/login-gov/openid/callback', publicPassport, SCRIPT_REDIRECT);
+router.get('/login-gov/openid/logout', (_req, res) => res.redirect('/auth/logout'));
 
 /* Admin user authentication */
 router.get('/admin/login', passport.authenticate('admin'));
-router.post('/admin/callback',
-  passport.authenticate('admin', { failureRedirect: INTAKE_CLIENT_BASE_URL }),
-  (_req, res) => res.send(`<script>window.location = '${INTAKE_CLIENT_BASE_URL}/logged-in'</script>`));
-
+router.post('/admin/callback', adminPassport, SCRIPT_REDIRECT);
 // TODO - eventually remove
-router.get('/login-gov/openid/callback', (_req, res) => {
-  res.redirect('/auth/public/callback');
-});
-router.get('/login-gov/openid/logout', (_req, res) => {
-  res.redirect('/auth/logout');
-});
-router.post('/usda-eauth/saml/callback',
-  passport.authenticate('admin', { failureRedirect: INTAKE_CLIENT_BASE_URL }),
-  (_req, res) => res.send(`<script>window.location = '${INTAKE_CLIENT_BASE_URL}/logged-in'</script>`));
+router.post('/usda-eauth/saml/callback', adminPassport, SCRIPT_REDIRECT);
 
 module.exports = router;

--- a/server/src/routers/auth.es6
+++ b/server/src/routers/auth.es6
@@ -37,6 +37,9 @@ router.post('/admin/callback',
 router.get('/login-gov/openid/callback', (_req, res) => {
   res.redirect('/auth/public/callback');
 });
+router.get('/login-gov/openid/logout', (_req, res) => {
+  res.redirect('/auth/logout');
+});
 router.post('/usda-eauth/saml/callback',
   passport.authenticate('admin', { failureRedirect: INTAKE_CLIENT_BASE_URL }),
   (_req, res) => res.send(`<script>window.location = '${INTAKE_CLIENT_BASE_URL}/logged-in'</script>`));


### PR DESCRIPTION
## Summary
Addresses Issue #654 

Revert `redirect_uri` in Login.gov configuration until it can be updated in Login.gov.

Please note if fully resolves the issue per the acceptance criteria: Y

## Impacted Areas of the Site
- Special Uses public user authentication

## This pull request changes...
- [x] Login.gov openid configuration

## This pull request is ready to merge when...
- [x] Verified in `dev`
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [] Server actions captured by logs (manual)
- [] Documentation / readme.md updated (manual)
- [] API docs updated if need (manual)
- [] JSDocs updated (manual)
- [] Docker updated if needed (manual)
- [x] This code has been reviewed by someone other than the original author
