### PR TITLE
Remove "code structure" header

### DIFF
--- a/docs/christmas-trees/README.md
+++ b/docs/christmas-trees/README.md
@@ -1,4 +1,3 @@
-[Code structure](/docs/christmas-trees/structure)
 
 [Content](/docs/christmas-trees/content)
 


### PR DESCRIPTION
This header was likely copied over from the middle layer API repo, which has a complex structure. Since the structure of the Christmas tree module is straightforward, a detailed description is not needed here.