### PR TITLE
#653 add admin/christmas-trees redirect

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -176,6 +176,11 @@ const appRoutes: Routes = [
     },
     children: [
       {
+        path: '',
+        redirectTo: 'reports',
+        pathMatch: 'full'
+      },
+      {
         path: 'reports',
         component: ReportComponent,
         data: {


### PR DESCRIPTION
## Summary
Addresses Issue #653 

Please note if fully resolves the issue per the acceptance criteria: Yes

Adds redirect to admin/christmas-trees to properly send to authentication and then load report component

## Impacted Areas of the Site
- admin/christmas-trees

## This pull request changes...
- [x] admin/christmas-trees now routes to login.gov, than redirects to admin/christmas-trees/reports

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
