### PR TITLE
Ignore authn context

### DIFF
--- a/server/src/auth/usda-eauth.es6
+++ b/server/src/auth/usda-eauth.es6
@@ -18,7 +18,8 @@ eAuth.strategy = () => new SamlStrategy(
     issuer: vcapConstants.EAUTH_ISSUER,
     privateCert: vcapConstants.EAUTH_PRIVATE_KEY,
     cert: vcapConstants.EAUTH_CERT,
-    identifierFormat: vcapConstants.EAUTH_IDENTIFIER_FORMAT || undefined
+    identifierFormat: vcapConstants.EAUTH_IDENTIFIER_FORMAT || undefined,
+    disableRequestedAuthnContext: vcapConstants.EAUTH_DISABLE_AUTHN_CONTEXT || undefined
   },
   (profile, done) => done(null, eAuth.setUserObject(profile))
 );

--- a/server/src/vcap-constants.es6
+++ b/server/src/vcap-constants.es6
@@ -90,6 +90,7 @@ vcapConstants.EAUTH_ENTRY_POINT = eAuthService.entrypoint;
 vcapConstants.EAUTH_CERT = eAuthService.cert;
 vcapConstants.EAUTH_PRIVATE_KEY = eAuthService.private_key;
 vcapConstants.EAUTH_IDENTIFIER_FORMAT = eAuthService.identifier_format;
+vcapConstants.EAUTH_DISABLE_AUTHN_CONTEXT = eAuthService.disable_authn_context;
 
 /** SMTP settings */
 const smtp = getUserProvided('smtp-service');


### PR DESCRIPTION
## Summary
Addresses Issue #663 

Please note if fully resolves the issue per the acceptance criteria: Y

Adds ability to configure `disableRequestedAuthnContext` SAML configuration parameter via environment variables.

Can be verified by authenticating in dev/staging/production: https://open-forest-dev.app.cloud.gov/admin/applications

## Impacted Areas of the Site
EAuth authentication

## This pull request changes...
- [x] available SAML configuration options

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [] Server actions captured by logs (manual)
- [] Documentation / readme.md updated (manual)
- [] API docs updated if need (manual)
- [] JSDocs updated (manual)
- [] Docker updated if needed (manual)
- [ ] This code has been reviewed by someone other than the original author
