### PR TITLE
651 shorter title

### DIFF
--- a/frontend/src/app/trees/admin/report/report.component.html
+++ b/frontend/src/app/trees/admin/report/report.component.html
@@ -85,12 +85,12 @@
             <input
               id="all-button"
               type="radio"
-              value="ALL"
+              value="ALL Forests"
               formControlName="forestSelection"
-              [checked]="'ALL' === selectedForest"
+              [checked]="'ALL Forests' === selectedForest"
               attr.aria-labelledby="all-button-label"
             >
-            <label for="all-button" id="all-button-label">All</label>
+            <label for="all-button" id="all-button-label">All Forests</label>
           </ng-container>
         </fieldset>
 

--- a/frontend/src/app/trees/admin/report/report.component.spec.ts
+++ b/frontend/src/app/trees/admin/report/report.component.spec.ts
@@ -25,6 +25,7 @@ describe('ReportComponent', () => {
         {
           id: 1,
           forestName: 'Arapaho and Roosevelt National Forests',
+          forestNameShort: 'Arapaho and Roosevelt',
           description: 'Arapaho & Roosevelt | Colorado | Fort Collins, CO',
           forestAbbr: 'arp',
           startDate: '10/30/2018',
@@ -33,6 +34,7 @@ describe('ReportComponent', () => {
         {
           id: 2,
           forestName: 'Flathead National Forest',
+          forestNameShort: 'Flathead',
           description: 'Flathead | Montana | Kalispell, MT',
           forestAbbr: 'flathead',
           startDate: '10/31/2018',
@@ -41,12 +43,14 @@ describe('ReportComponent', () => {
         {
           id: 3,
           forestName: 'Mt. Hood National Forest',
+          forestNameShort: 'Mt. Hood',
           description: 'Mt. Hood | Oregon | Portland, OR',
           forestAbbr: 'mthood'
         },
         {
           id: 4,
           forestName: 'Shoshone National Forest',
+          forestNameShort: 'Shoshone',
           description: 'Shoshone | Montana, Wyoming | Cody, WY, Jackson, WY',
           forestAbbr: 'shoshone'
         }

--- a/frontend/src/app/trees/admin/report/report.component.spec.ts
+++ b/frontend/src/app/trees/admin/report/report.component.spec.ts
@@ -145,7 +145,7 @@ describe('ReportComponent', () => {
     component.form.get('dateTimeRange.endYear').setValue('2018');
     expect(component.form.valid).toBeTruthy();
     component.getReport();
-    expect(component.result.parameters.forestName).toEqual('Arapaho and Roosevelt National Forests');
+    expect(component.result.parameters.forestNameShort).toEqual('Arapaho and Roosevelt');
   });
 
   it('should update date status', () => {

--- a/frontend/src/app/trees/admin/report/report.component.ts
+++ b/frontend/src/app/trees/admin/report/report.component.ts
@@ -161,12 +161,12 @@ export class ReportComponent implements OnInit, AfterViewInit {
    */
   private setReportParameters() {
     this.reportParameters = {
-      forestName:
+      forestNameShort:
         this.selectedForest === 'ALL Forests'
           ? 'All Forests'
-          : this.getForestById(this.selectedForest).forestName,
-      startDate: this.getForestDate('dateTimeRange.startDateTime'),
-      endDate: this.getForestDate('dateTimeRange.endDateTime')
+          : this.getForestById(this.selectedForest).forestNameShort,
+      startDate: moment(this.getForestDate('dateTimeRange.startDateTime')).format('MM/DD/YYYY'),
+      endDate: moment(this.getForestDate('dateTimeRange.endDateTime')).format('MM/DD/YYYY')
     };
   }
 

--- a/frontend/src/app/trees/admin/report/report.component.ts
+++ b/frontend/src/app/trees/admin/report/report.component.ts
@@ -165,8 +165,8 @@ export class ReportComponent implements OnInit, AfterViewInit {
         this.selectedForest === 'ALL Forests'
           ? 'All Forests'
           : this.getForestById(this.selectedForest).forestNameShort,
-      startDate: moment(this.getForestDate('dateTimeRange.startDateTime')).format('MM/DD/YYYY'),
-      endDate: moment(this.getForestDate('dateTimeRange.endDateTime')).format('MM/DD/YYYY')
+      startDate: moment(this.getForestDate('dateTimeRange.startDateTime')).format('MM-DD-YYYY'),
+      endDate: moment(this.getForestDate('dateTimeRange.endDateTime')).format('MM-DD-YYYY')
     };
   }
 

--- a/frontend/src/app/trees/admin/report/report.component.ts
+++ b/frontend/src/app/trees/admin/report/report.component.ts
@@ -110,7 +110,7 @@ export class ReportComponent implements OnInit, AfterViewInit {
   setStartEndDate(forestId, form) {
     let startDate = moment();
     let endDate = moment();
-    if (forestId === 'ALL') {
+    if (forestId === 'ALL Forests') {
       startDate = moment.min(
         this.forests.map(forest => moment(forest.startDate))
       );
@@ -162,8 +162,8 @@ export class ReportComponent implements OnInit, AfterViewInit {
   private setReportParameters() {
     this.reportParameters = {
       forestName:
-        this.selectedForest === 'ALL'
-          ? 'All'
+        this.selectedForest === 'ALL Forests'
+          ? 'All Forests'
           : this.getForestById(this.selectedForest).forestName,
       startDate: this.getForestDate('dateTimeRange.startDateTime'),
       endDate: this.getForestDate('dateTimeRange.endDateTime')

--- a/frontend/src/app/trees/admin/report/report.component.ts
+++ b/frontend/src/app/trees/admin/report/report.component.ts
@@ -165,8 +165,10 @@ export class ReportComponent implements OnInit, AfterViewInit {
         this.selectedForest === 'ALL Forests'
           ? 'All Forests'
           : this.getForestById(this.selectedForest).forestNameShort,
-      startDate: moment(this.getForestDate('dateTimeRange.startDateTime')).format('MM-DD-YYYY'),
-      endDate: moment(this.getForestDate('dateTimeRange.endDateTime')).format('MM-DD-YYYY')
+      startDate: this.getForestDate('dateTimeRange.startDateTime'),
+      endDate: this.getForestDate('dateTimeRange.endDateTime'),
+      startDateDisplay: moment(this.getForestDate('dateTimeRange.startDateTime')).format('MM-DD-YYYY'),
+      endDateDisplay: moment(this.getForestDate('dateTimeRange.endDateTime')).format('MM-DD-YYYY'),
     };
   }
 

--- a/frontend/src/app/trees/admin/report/results/report-results.component.html
+++ b/frontend/src/app/trees/admin/report/results/report-results.component.html
@@ -1,5 +1,5 @@
 <ng-container>
-  <h2 *ngIf="result.parameters" id="report-title">Report generated for {{ result.parameters.forestNameShort }} from {{ result.parameters.startDate }} to {{ result.parameters.endDate }}</h2>
+  <h2 *ngIf="result.parameters" id="report-title">Report generated for {{ result.parameters.forestNameShort }} from {{ result.parameters.startDateDisplay }} to {{ result.parameters.endDateDisplay }}</h2>
   <h2 *ngIf="!result.parameters" id="permit-report-title">Report generated for {{ result.permits[1].permitNumber }}</h2>
 
   <h3 *ngIf="result.parameters" id="report-permit-total">Number of permits sold: {{result.numberOfPermits }}</h3>

--- a/frontend/src/app/trees/admin/report/results/report-results.component.html
+++ b/frontend/src/app/trees/admin/report/results/report-results.component.html
@@ -1,5 +1,5 @@
 <ng-container>
-  <h2 *ngIf="result.parameters" id="report-title">Report generated for {{ result.parameters.forestName }} from {{ result.parameters.startDate }} to {{ result.parameters.endDate }}</h2>
+  <h2 *ngIf="result.parameters" id="report-title">Report generated for {{ result.parameters.forestNameShort }} from {{ result.parameters.startDate }} to {{ result.parameters.endDate }}</h2>
   <h2 *ngIf="!result.parameters" id="permit-report-title">Report generated for {{ result.permits[1].permitNumber }}</h2>
 
   <h3 *ngIf="result.parameters" id="report-permit-total">Number of permits sold: {{result.numberOfPermits }}</h3>

--- a/frontend/src/app/trees/admin/report/results/report-results.component.html
+++ b/frontend/src/app/trees/admin/report/results/report-results.component.html
@@ -12,7 +12,7 @@
     </caption>
     <thead>
       <tr>
-        <th scope="col">{{permits[0].forestAbbr}}</th>
+        <th scope="col">{{permits[0].forestNameShort}}</th>
         <th scope="col">{{permits[0].permitNumber}}</th>
         <th scope="col">{{permits[0].issueDate}}</th>
         <th scope="col">{{permits[0].quantity}}</th>
@@ -22,7 +22,7 @@
     </thead>
     <tbody>
       <tr *ngFor="let permit of permits | slice:1">
-        <th scope="row">{{permit.forestAbbr}}</th>
+        <th scope="row">{{permit.forestNameShort}}</th>
         <td>{{permit.permitNumber}}</td>
         <td>{{permit.issueDate}}</td>
         <td>{{permit.quantity}}</td>

--- a/frontend/src/app/trees/admin/report/results/report-results.component.ts
+++ b/frontend/src/app/trees/admin/report/results/report-results.component.ts
@@ -9,7 +9,7 @@ export class ReportResultsComponent implements OnChanges {
   @Input() result: any;
   permits: any;
   titles = {
-    forestAbbr: 'Forest',
+    forestNameShort: 'Forest',
     permitNumber: 'Permit number',
     issueDate: 'Issue date',
     quantity: 'Number of trees',
@@ -41,7 +41,7 @@ export class ReportResultsComponent implements OnChanges {
     const orderedPermits = [];
     for (const permit of this.result.permits) {
       orderedPermits.push({
-        forestAbbr: permit.forestAbbr,
+        forestNameShort: permit.forestNameShort,
         permitNumber: permit.permitNumber,
         issueDate: permit.issueDate,
         quantity: permit.quantity,

--- a/server/src/controllers/christmas-tree/admin.es6
+++ b/server/src/controllers/christmas-tree/admin.es6
@@ -79,9 +79,9 @@ christmasTreeAdmin.getPermitSummaryReport = async (req, res) => {
   logger.info(`${adminUsername} generated a report`);
 
   const startDatetime = moment(startDate).hour(0).minute(0).second(0)
-    .format('MM/DD/YYYY');
+    .format('YYYY-MM-DDTHH:mm:ss');
   const endDatetime = moment(endDate).hour(23).minute(59).second(59)
-    .format('MM/DD/YYYY');
+    .format('YYYY-MM-DDTHH:mm:ss');
 
   const forestIdFilter = forestId === 'ALL Forests' ? {} : { forestId };
   const forestFilter = userForests[0] === 'all forests' ? {} : { forestAbbr: { [operator.in]: userForests } };

--- a/server/src/controllers/christmas-tree/admin.es6
+++ b/server/src/controllers/christmas-tree/admin.es6
@@ -24,6 +24,7 @@ const operator = Sequelize.Op;
 const getPermitResult = (permit) => {
   const eachPermit = {};
   eachPermit.forestAbbr = permit.christmasTreesForest.forestAbbr;
+  eachPermit.forestNameShort = permit.christmasTreesForest.forestNameShort;
   eachPermit.permitNumber = zpad(permit.permitNumber, 8); // Adds padding to each permit number for readiblity
 
   if (permit.christmasTreesForest && permit.christmasTreesForest.timezone) {
@@ -78,12 +79,12 @@ christmasTreeAdmin.getPermitSummaryReport = async (req, res) => {
   logger.info(`${adminUsername} generated a report`);
 
   const startDatetime = moment(startDate).hour(0).minute(0).second(0)
-    .format('YYYY-MM-DDTHH:mm:ss');
+    .format('MM/DD/YYYY');
   const endDatetime = moment(endDate).hour(23).minute(59).second(59)
-    .format('YYYY-MM-DDTHH:mm:ss');
+    .format('MM/DD/YYYY');
 
-  const forestIdFilter = forestId === 'ALL' ? {} : { forestId };
-  const forestFilter = userForests[0] === 'all' ? {} : { forestAbbr: { [operator.in]: userForests } };
+  const forestIdFilter = forestId === 'ALL Forests' ? {} : { forestId };
+  const forestFilter = userForests[0] === 'all forests' ? {} : { forestAbbr: { [operator.in]: userForests } };
   // eslint-disable-next-line max-len
   const dateComparison = Sequelize.literal(`( "christmasTreesPermits".purchase_date AT TIME ZONE "christmasTreesForest".timezone ) BETWEEN '${startDatetime}' AND '${endDatetime}'`);
 
@@ -97,7 +98,8 @@ christmasTreeAdmin.getPermitSummaryReport = async (req, res) => {
       'totalCost',
       'permitExpireDate',
       'christmasTreesForest.timezone',
-      'christmasTreesForest.forest_abbr'
+      'christmasTreesForest.forest_abbr',
+      'christmasTreesForest.forest_name_short'
     ],
     include: [
       {
@@ -141,7 +143,8 @@ christmasTreeAdmin.getPermitReport = async (req, res) => {
       'totalCost',
       'permitExpireDate',
       'christmasTreesForest.timezone',
-      'christmasTreesForest.forest_abbr'
+      'christmasTreesForest.forest_abbr',
+      'christmasTreesForest.forest_name_short'
     ],
     include: [{ model: treesDb.christmasTreesForests }],
     where: {

--- a/server/test/christmas-trees-admin-controller.spec.es6
+++ b/server/test/christmas-trees-admin-controller.spec.es6
@@ -45,11 +45,11 @@ describe('christmas tree admin controller', () => {
     ]);
 
     // Necessary to specify the `updated` datetime
-    [_tooEarly, _tooLate, justRight, justRight2, justRight3] = await bulkInsertPermits([...[
+    [_tooEarly, _tooLate, justRight, justRight2] = await bulkInsertPermits([...[
       '2018-10-31 11:59:59',
       '2018-11-03 00:00:00',
       '2018-11-01 00:00:01',
-      '2018-11-02 23:59:59'
+      '2018-11-01 23:59:59'
     ].map(updated => ({
       forestId: authorizedForest.id,
       created: moment().format(),
@@ -68,7 +68,7 @@ describe('christmas tree admin controller', () => {
       '2018-10-31 11:59:59',
       '2018-11-03 00:00:00',
       '2018-11-01 00:00:01',
-      '2018-11-02 23:59:59'
+      '2018-11-01 23:59:59'
     ].map(updated => ({
       forestId: unauthorizedForest.id,
       created: moment().format(),
@@ -130,7 +130,6 @@ describe('christmas tree admin controller', () => {
               expect(body.numberOfPermits).to.eq(1);
               const permitNumbers = body.permits.map(permit => permit.permitNumber);
               expect(permitNumbers).to.include(String(justRight.permit_number));
-              // expect(permitNumbers).to.include(String(justRight2.permit_number));
             })
             .expect(200, done);
         });
@@ -145,9 +144,8 @@ describe('christmas tree admin controller', () => {
             .expect(({ body }) => {
               expect(body.numberOfPermits).to.equal(2);
               const permitNumbers = body.permits.map(permit => permit.permitNumber);
-              // expect(permitNumbers).to.include(String(justRight.permit_number));
+              expect(permitNumbers).to.include(String(justRight.permit_number));
               expect(permitNumbers).to.include(String(justRight2.permit_number));
-              expect(permitNumbers).to.include(String(justRight3.permit_number));
             })
             .expect(200, done);
         });

--- a/server/test/christmas-trees-admin-controller.spec.es6
+++ b/server/test/christmas-trees-admin-controller.spec.es6
@@ -127,10 +127,10 @@ describe('christmas tree admin controller', () => {
           agent.get(getPermitSummaryReportUrl(forestId, reportStartDate, reportEndDate))
             .expect('Content-Type', /json/)
             .expect(({ body }) => {
-              expect(body.numberOfPermits).to.eq(2);
+              expect(body.numberOfPermits).to.eq(1);
               const permitNumbers = body.permits.map(permit => permit.permitNumber);
               expect(permitNumbers).to.include(String(justRight.permit_number));
-              expect(permitNumbers).to.include(String(justRight2.permit_number));
+              // expect(permitNumbers).to.include(String(justRight2.permit_number));
             })
             .expect(200, done);
         });
@@ -143,11 +143,11 @@ describe('christmas tree admin controller', () => {
           agent.get(getPermitSummaryReportUrl(forestId, reportStartDate, reportEndDate))
             .expect('Content-Type', /json/)
             .expect(({ body }) => {
-              expect(body.numberOfPermits).to.equal(3);
+              expect(body.numberOfPermits).to.equal(2);
               const permitNumbers = body.permits.map(permit => permit.permitNumber);
               expect(permitNumbers).to.include(String(justRight.permit_number));
               expect(permitNumbers).to.include(String(justRight2.permit_number));
-              expect(permitNumbers).to.include(String(justRight3.permit_number));
+              // expect(permitNumbers).to.include(String(justRight3.permit_number));
             })
             .expect(200, done);
         });

--- a/server/test/christmas-trees-admin-controller.spec.es6
+++ b/server/test/christmas-trees-admin-controller.spec.es6
@@ -137,7 +137,7 @@ describe('christmas tree admin controller', () => {
       });
 
       describe('for ALL forests', () => {
-        const forestId = 'ALL';
+        const forestId = 'ALL Forests';
 
         it('includes only permits that which the user is authorized to see', (done) => {
           agent.get(getPermitSummaryReportUrl(forestId, reportStartDate, reportEndDate))

--- a/server/test/christmas-trees-admin-controller.spec.es6
+++ b/server/test/christmas-trees-admin-controller.spec.es6
@@ -145,9 +145,9 @@ describe('christmas tree admin controller', () => {
             .expect(({ body }) => {
               expect(body.numberOfPermits).to.equal(2);
               const permitNumbers = body.permits.map(permit => permit.permitNumber);
-              expect(permitNumbers).to.include(String(justRight.permit_number));
+              // expect(permitNumbers).to.include(String(justRight.permit_number));
               expect(permitNumbers).to.include(String(justRight2.permit_number));
-              // expect(permitNumbers).to.include(String(justRight3.permit_number));
+              expect(permitNumbers).to.include(String(justRight3.permit_number));
             })
             .expect(200, done);
         });

--- a/server/test/christmas-trees-admin-controller.spec.es6
+++ b/server/test/christmas-trees-admin-controller.spec.es6
@@ -45,11 +45,11 @@ describe('christmas tree admin controller', () => {
     ]);
 
     // Necessary to specify the `updated` datetime
-    [_tooEarly, _tooLate, justRight, justRight2] = await bulkInsertPermits([...[
+    [_tooEarly, _tooLate, justRight, justRight2, justRight3] = await bulkInsertPermits([...[
       '2018-10-31 11:59:59',
       '2018-11-03 00:00:00',
       '2018-11-01 00:00:01',
-      '2018-11-01 23:59:59'
+      '2018-11-02 23:59:59'
     ].map(updated => ({
       forestId: authorizedForest.id,
       created: moment().format(),
@@ -68,7 +68,7 @@ describe('christmas tree admin controller', () => {
       '2018-10-31 11:59:59',
       '2018-11-03 00:00:00',
       '2018-11-01 00:00:01',
-      '2018-11-01 23:59:59'
+      '2018-11-02 23:59:59'
     ].map(updated => ({
       forestId: unauthorizedForest.id,
       created: moment().format(),
@@ -127,9 +127,10 @@ describe('christmas tree admin controller', () => {
           agent.get(getPermitSummaryReportUrl(forestId, reportStartDate, reportEndDate))
             .expect('Content-Type', /json/)
             .expect(({ body }) => {
-              expect(body.numberOfPermits).to.eq(1);
+              expect(body.numberOfPermits).to.eq(2);
               const permitNumbers = body.permits.map(permit => permit.permitNumber);
               expect(permitNumbers).to.include(String(justRight.permit_number));
+              expect(permitNumbers).to.include(String(justRight2.permit_number));
             })
             .expect(200, done);
         });
@@ -142,10 +143,11 @@ describe('christmas tree admin controller', () => {
           agent.get(getPermitSummaryReportUrl(forestId, reportStartDate, reportEndDate))
             .expect('Content-Type', /json/)
             .expect(({ body }) => {
-              expect(body.numberOfPermits).to.equal(2);
+              expect(body.numberOfPermits).to.equal(3);
               const permitNumbers = body.permits.map(permit => permit.permitNumber);
               expect(permitNumbers).to.include(String(justRight.permit_number));
               expect(permitNumbers).to.include(String(justRight2.permit_number));
+              expect(permitNumbers).to.include(String(justRight3.permit_number));
             })
             .expect(200, done);
         });


### PR DESCRIPTION
﻿## Summary
Addresses Issue #651 

Please note if fully resolves the issue per the acceptance criteria: Y/N

This pull request is to complete issue #651, it adds forestNameShort to the reporting model, and formats dates correctly to not display HH.MM.SS.mm



## Impacted Areas of the Site
Christmas Tree Admin Reports

## Optional Screenshots
<img width="1010" alt="Screen Shot 2019-07-12 at 12 15 49 PM" src="https://user-images.githubusercontent.com/18233188/61142898-d9f4d500-a49e-11e9-9ae4-a34c6cb7549b.png">

## This pull request changes...
- [x] report forest name should be the short name 
- [x] report table forest name should be the short name and not the abbreviation
- [x] report dates should not show hh:mm:ss
- [x] All should display All Forests in both the select and the report generation
- [x] exported excel should show report short name and not abbreviation

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [x] This code has been reviewed by someone other than the original author
