### PR TITLE
725 - small adjustment to photo credit for white fir

### DIFF
--- a/frontend/src/assets/config/christmasTreesForests-deschutes.json
+++ b/frontend/src/assets/config/christmasTreesForests-deschutes.json
@@ -18,7 +18,7 @@
       "id": "white-fir",
       "name": "White Fir",
       "status": "recommended",
-      "photoCredits": "Photo from: https://www.fs.usda.gov/detail/sierra/home/?cid=stelprdb5150508"
+      "photoCredits": "https://www.fs.usda.gov/detail/sierra/home/?cid=stelprdb5150508"
     },
     {
       "id": "lodgepole-pine",


### PR DESCRIPTION
﻿## Summary
Addresses Issue # 725

Please note if fully resolves the issue per the acceptance criteria: Y

This changes the photo credits for white fir

## Impacted Areas of the Site
- White fir photo credits

## This pull request changes...
- [ ] The photo credits for white fir

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
